### PR TITLE
- Extracted and cleaned 'Title' data to separate 'Fuel Type' and 'Year'.

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/ML-Car-Price-Prediction.iml
+++ b/.idea/ML-Car-Price-Prediction.iml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="PYTHON_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$" />
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyInterpreterInspection" enabled="false" level="WARNING" enabled_by_default="false" />
+  </profile>
+</component>

--- a/.idea/inspectionProfiles/profiles_settings.xml
+++ b/.idea/inspectionProfiles/profiles_settings.xml
@@ -1,0 +1,6 @@
+<component name="InspectionProjectProfileManager">
+  <settings>
+    <option name="USE_PROJECT_PROFILE" value="false" />
+    <version value="1.0" />
+  </settings>
+</component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Black">
+    <option name="sdkName" value="Python 3.13 (MachineLearning)" />
+  </component>
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13 (MachineLearning)" project-jdk-type="Python SDK" />
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/ML-Car-Price-Prediction.iml" filepath="$PROJECT_DIR$/.idea/ML-Car-Price-Prediction.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/clean_data/preset1.csv
+++ b/clean_data/preset1.csv
@@ -1,0 +1,829 @@
+Price,Title,Fuel,Mileage,Year
+35 000,KIA Rio Berline,Essence,163 746,2016
+105 000,Peugeot 3008,Essence,55 000,2022
+30 500,Renault Clio Campus climatisée,Essence,116 000,2012
+52 000,Chery Tiggo 3X Luxury,Essence,47 000,2022
+32 000,Peugeot 3008,Essence,210 000,2010
+52 000,KIA Rio Berline,Essence,90 500,2020
+43 500,Hyundai Grand i10,Essence,43 200,2021
+58 000,MG 5,Essence,37 000,2022
+73 500,Mercedes-Benz Classe C,Essence,159 000,2012
+260 000,Mercedes-Benz GLC Coupé AMG,Hybride,47 000,2021
+77 000,Haval H6 Luxury,Essence,100 000,2019
+67 000,Mercedes-Benz Classe E,Essence,197 000,2010
+178 000,Mercedes-Benz Classe C coupé AMG,Hybride,86 000,2019
+122 000,Land Rover Range Rover Evoque R-Dynamic,Diesel,150 000,2016
+145 000,BMW Série 4 Gran Coupé,Essence,90 000,2019
+258 000,Land Rover Range Rover Velar R-Dynamic,Diesel,55 000,2020
+189 000,Mercedes-Benz GLA AMG,Essence,20 000,2023
+97 500,Hyundai Kona Hybride N Line,Hybride,19 500,2020
+112 000,Audi Q3,Essence,110 000,2019
+152 000,Porsche Cayenne,Essence,195 000,2012
+103 000,MG HS Trophy,Essence,35 000,2021
+122 000,Mercedes-Benz Classe S S 350 phase 2,Essence,165 000,2010
+Sous leasing                    161 300,Mercedes-Benz Classe C AMG,Essence,135 000,2019
+72 000,Volkswagen Golf 7 Join,Essence,83 000,2018
+98 000,Mercedes-Benz Classe S S350. Toit ouvrant,Essence,147 000,2009
+56 000,Peugeot Partner Origin Utilitaire Pack Clim PM,Diesel,73 000,2019
+95 000,KIA Sportage GT-Line,Diesel,139 000,2018
+155 000,Cupra Formentor Sport,Essence,41 000,2022
+165 000,Mercedes-Benz Classe C AMG,Hybride,54 000,2018
+165 000,Mercedes-Benz Classe C AMG,Hybride,69 000,2020
+75 000,Volkswagen Golf 7 Confortline,Essence,69 000,2020
+51 000,KIA Rio 5p,Essence,145 000,2019
+145 000,Mercedes-Benz Classe A,Hybride,66 000,2021
+95 000,Volkswagen Golf 7,Essence,88 000,2018
+55 000,BMW Série 1,Essence,144 000,2015
+76 500,Volkswagen Golf 7 Join,Essence,120 000,2020
+199 000,BMW X2 Lounge,Essence,0,2024
+169 000,Land Rover Range Rover Evoque R-Dynamic,Diesel,59 000,2021
+110 000,Volkswagen Golf 8 R-Line,Hybride,12 000,2022
+122 000,Mercedes-Benz GLA AMG,Essence,30 000,2018
+259 000,Mercedes-Benz GLC Coupé AMG,Hybride,50 000,2021
+174 000,Mercedes-Benz Classe C AMG +,Essence,60 000,2021
+155 000,Volkswagen T-roc 1.5,Hybride,9 000,2024
+197 000,Mercedes-Benz Classe C AMG,Essence,32 000,2022
+218 000,Land Rover Range Rover Evoque R-Dynamic S,Hybride,59 000,2021
+115 000,Volkswagen Golf 8,Hybride,40 000,2020
+248 000,Mercedes-Benz Classe C AMG +,Hybride,11 000,2024
+89 500,Suzuki Jimny,Essence,60 000,2021
+68 000,Mercedes-Benz Classe E coupé AMG,Essence,180 000,2010
+98 000,Volkswagen T-roc Toit ouvrant,Essence,44 000,2020
+99 500,Mercedes-Benz Classe C AMG,Essence,180 000,2016
+184 000,Mercedes-Benz GLB AMG,Essence,16 000,2023
+435 000,Mercedes-Benz Classe E AMG,Hybride,0,2024
+109 000,Mercedes-Benz Classe C AMG,Essence,175 000,2016
+124 500,BMW Série 5 Luxury Line,Essence,155 000,2017
+169 000,Mercedes-Benz Classe A A200,Hybride,8 000,2024
+149 000,KIA Sportage GT-Line,Hybride,40 000,2023
+268 000,Land Rover Range Rover Velar R-Dynamic,Essence,33 000,2019
+158 000,BMW Série 7 B7 ALPINA,Essence,115 000,2011
+89 500,Volkswagen Golf 8 ÉDITION,Essence,45 000,2021
+450 000,Mercedes-Benz Classe E AMG,Hybride,0,2024
+415 000,Mercedes-Benz GLC Coupé AMG,Essence,0,2024
+169 000,Mercedes-Benz CLA AMG,Hybride,42 000,2020
+295 000,Audi Q5 Sportback S-Line,Hybride,45 000,2022
+124 000,Mercedes-Benz Classe A A 200,Essence,57 000,2018
+188 000,Mercedes-Benz CLA AMG,Essence,30 000,2023
+178 000,Land Rover Range Rover Sport,Essence,180 000,2014
+535 000,Porsche Panamera 4S E-hybride plugin,Hybride,32 000,2021
+225 000,Mercedes-Benz GLC Coupé AMG,Essence,106 000,2016
+175 000,Audi Q3 Sportback hybrid,Hybride,50 000,2021
+380 000,Porsche Cayenne Coupé,Essence,37 000,2020
+269 000,Jaguar F-Pace R-Dynamic S,Essence,27 000,2021
+129 000,BMW X1 FACELIFT PACK M,Essence,87 000,2020
+168 000,Mitsubishi L200 Sportero,Diesel,19 000,2022
+510 000,Porsche Cayenne,Hybride,15 000,2022
+147 000,Audi A5 Sportback S-Line,Essence,85 000,2020
+88 000,Mercedes-Benz ML,Diesel,231 000,2010
+148 000,Mercedes-Benz CLA,Diesel,93 000,2020
+98 000,BMW X6,Essence,180 000,2011
+245 000,Mercedes-Benz GLC Coupé,Hybride,70 000,2020
+350 000,Mercedes-Benz Classe G,Diesel,168 000,2010
+85 000,Peugeot 508,Essence,46 000,2020
+132 000,Seat Leon Cupra,Essence,74 000,2020
+48 000,Volkswagen Touareg,Diesel,308 000,2006
+195 000,Mercedes-Benz Classe S,Hybride,79 000,2015
+83 000,Peugeot 508,Essence,137 000,2019
+340 000,Land Rover Range Rover Sport,Hybride,100 000,2019
+178 000,BMW Série 5,Essence,93 000,2020
+400 000,Mercedes-Benz GLC Coupé,Essence,0,2024
+208 000,BMW Série 5,Essence,32 000,2021
+630 000,Mercedes-Benz Classe G AMG,Essence,30 000,2015
+158 000,Mercedes-Benz GLC,Essence,83 000,2016
+174 000,Mercedes-Benz CLA,Hybride,69 000,2021
+30 500,Citroën DS3,Essence,92 000,2017
+100 000,Mini Clubman,Essence,34 000,2019
+450 000,Mercedes-Benz Classe S,Hybride,40 000,2020
+95 000,Nissan Qashqai,Essence,26 000,2022
+245 000,Mercedes-Benz Classe E,Essence,9 000,2022
+360 000,Mercedes-Benz GLC Coupé,Essence,6 600,2023
+170 000,Audi A5 Sportback,Essence,58 000,2021
+98 000,Seat Ateca,Essence,85 000,2020
+410 000,Porsche Cayenne E-Hybrid,Hybride,86 000,2019
+54 500,KIA Picanto GT-Line,Essence,63 000,2022
+88 000,Toyota Prado,Diesel,449 000,2003
+47 000,BYD F3,Essence,10 000,2022
+350 000,Land Rover Range Rover Sport,Hybride,37 000,2020
+115 000,Volkswagen Golf 7,Essence,73 000,2017
+375 000,Porsche Macan,Essence,6 900,2023
+174 000,BMW Série 3,Essence,80 000,2021
+190 000,Audi Q3,Essence,2 000,2024
+370 000,Porsche Cayenne Coupé,Essence,59 000,2019
+350 000,Toyota Land Cruiser,Diesel,98 000,2016
+58 000,Mini 5 portes,Essence,75 000,2015
+340 000,Mercedes-Benz Classe E coupé,Hybride,86 000,2018
+82 000,Peugeot 3008,Essence,87 000,2019
+56 000,Toyota RAV 4,Essence,280 000,2016
+45 500,Fiat 500 C,Essence,71 000,2017
+240 000,Mercedes-Benz GLC Coupé,Diesel,52 000,2020
+42 000,Suzuki Swift,Essence,69 000,2020
+76 000,Toyota Corolla,Essence,32 000,2022
+92 500,Ssangyong Korando,Essence,80 000,2021
+225 000,Jeep Wrangler Sahara,Essence,115 000,2018
+40 000,Peugeot 2008 Allure,Essence,96 000,2015
+100 000,BMW Série 4 Gran Coupé,Essence,121 000,2019
+95 000,Volkswagen Tiguan,Essence,123 000,2021
+59 000,BMW Série 3 318i,Essence,200 000,2015
+25 500,Peugeot 307,Essence,110 451,2007
+118 000,Mercedes-Benz Classe A AMG,Diesel,96 000,2019
+139 500,Mini Countryman All4,Hybride,33 000,2020
+58 000,MG ZS,Essence,110 000,2021
+245 000,Mercedes-Benz Classe C,Essence,7 300,2022
+120 000,KIA Sportage Hybride,Hybride,53 000,2020
+115 000,BMW Série 1 Pack M,Essence,110,2020
+55 000,Fiat 500 Dolcevita,Hybride,78 000,2021
+49 500,Fiat Tipo 5 portes,Essence,68 000,2021
+49 500,Renault Clio,Diesel,138 000,2020
+99 000,Mercedes-Benz Classe C,Essence,158 000,2015
+39 500,Suzuki Celerio,Essence,0,2024
+48 500,Volkswagen Golf 7,Essence,153 000,2015
+59 500,Renault Megane,Diesel,148 000,2021
+45 500,Peugeot 208 Style,Diesel,128 000,2020
+78 000,Audi Q5 S-line,Diesel,270 000,2014
+38 500,Citroën C1 Importée Tn245,Essence,56 000,2021
+76 000,Haval H6 Luxury,Essence,138 000,2021
+79 000,Peugeot 3008,Diesel,148 000,2020
+57 000,Volkswagen Amarok TDI 4*4,Diesel,198 000,2012
+145 000,Mercedes-Benz CLA AMG,Diesel,138 000,2020
+118 000,Mercedes-Benz CLA Importée Tn245,Diesel,138 000,2020
+149 000,Mercedes-Benz CLA,Essence,87 000,2021
+110 000,Volkswagen Golf 8 STYLE 1.5 BVA eTSI  importée,Essence,87 000,2021
+98 000,KIA Sportage GT-Line,Diesel,119 000,2019
+99 000,Haval H6,Essence,16 000,2022
+185 000,BMW Série 5 Pack M,Essence,70 000,2021
+107 000,BMW Série 4 Gran Coupé,Essence,53 000,2020
+30 000,Hyundai Grand i10 Sedan,Essence,150 000,2017
+135 000,Mercedes-Benz Classe C AMG +,Essence,146 000,2015
+95 000,Volkswagen Golf 8 Active,Essence,69 000,2021
+420 000,Mercedes-Benz GLE Coupé,Diesel,54 000,2020
+115 000,Mazda CX-5 High Grade,Essence,63 000,2019
+65 000,MG ZS,Essence,65 000,2019
+70 000,Seat Leon,Essence,61 847,2020
+97 000,Mercedes-Benz CLA Urban,Essence,125 043,2018
+150 000,KIA Sportage Hybride GT-Line,Hybride,36 000,2023
+54 000,KIA Rio 5p SX,Essence,68 954,2019
+75 000,Volkswagen Golf 7 Highline,Essence,26 043,2016
+87 000,Volkswagen Golf 8 Life,Essence,70 001,2020
+175 000,Toyota Land Cruiser,Diesel,142 060,2010
+69 000,Volkswagen Golf 7 Confortline,Essence,169 452,2019
+40 000,BMW Série 1,Essence,131 766,2009
+165 000,Mercedes-Benz Classe E AMG,Essence,55 001,2019
+275 000,Mercedes-Benz Classe C AMG +,Essence,0,2024
+235 000,Mercedes-Benz GLA La nouvelle Gla 250e AMG,Hybride,10 730,2023
+390 000,Mercedes-Benz Classe E AMG,Essence,10 776,2023
+65 000,BMW X3 Luxury Line,Diesel,186 000,2006
+185 000,Mercedes-Benz Classe C AMG,Essence,50 893,2022
+43 000,KIA Picanto Populaire,Essence,3 805,2021
+36 000,Lada 4x4 Urban,Essence,24 387,2018
+126 000,Haval H6,Essence,12 442,2023
+51 000,Nissan Juke Tekna,Essence,163 166,2014
+160 000,Mitsubishi Pajero LIMITED EDITION,Diesel,20 742,2023
+169 900,Mercedes-Benz CLA AMG Edition 1,Hybride,31 235,2021
+64 000,Peugeot 308 GT-Line GT-Line,Diesel,96 300,2020
+129 000,Toyota Prado,Diesel,199 425,2003
+135 000,Mini 5 portes,Essence,18 000,2021
+62 000,BMW Série 3 coupé,Essence,156 000,2010
+30 000,Mahindra KUV 100 K6+,Essence,63 000,2021
+93 000,Haval Jolion 1 ere,Essence,30 000,2023
+126 000,Peugeot 308,Diesel,48 000,2023
+198 000,Volkswagen Tiguan R-Line,Essence,54 723,2023
+59 000,Peugeot Expert,Diesel,139 199,2019
+138 000,Volkswagen Golf 8 R-Line,Hybride,36 651,2022
+48 000,Mini Cabrio,Essence,86 111,2010
+61 000,KIA Picanto 1 ère main,Essence,0,2024
+275 000,Porsche Cayman S,Essence,39 508,2008
+54 000,Seat Ibiza,Essence,99 519,2021
+119 000,Toyota Land Cruiser,Diesel,316 620,2003
+230 000,Mercedes-Benz GLC Coupé AMG,Hybride,82 415,2020
+65 000,Mercedes-Benz Classe C AMG,Essence,249 000,2011
+178 000,Mercedes-Benz Classe C,Essence,30 570,2021
+71 000,Peugeot 3008,Essence,105 000,2017
+225 000,Mercedes-Benz CLA AMG,Hybride,1 000,2024
+88 000,Volkswagen Golf 8,Essence,85 181,2020
+79 000,Volkswagen Golf 7 Join,Essence,86 000,2018
+78 000,Volkswagen T-roc,Essence,74 107,2019
+36 000,Renault Symbol,Essence,115 000,2020
+185 000,Mercedes-Benz CLA AMG,Hybride,18 500,2023
+135 000,Mercedes-Benz Classe A AMG,Essence,68 000,2018
+65 000,BMW Série 3 Luxury,Essence,112 000,2013
+110 000,Audi Q5 S-line,Diesel,176 000,2015
+145 000,Mercedes-Benz Classe C AMG,Diesel,145 000,2019
+50 000,Peugeot 2008 Allure Toit Cielo Blanc Nacré,Essence,125 000,2018
+119 000,Mercedes-Benz Classe A AMG,Diesel,141 000,2019
+145 000,Volkswagen Golf 8 GTE,Hybride,26 000,2021
+220 000,Mercedes-Benz CLA AMG,Hybride,6 000,2024
+78 000,Mercedes-Benz Classe A AMG Premium,Essence,131 000,2013
+46 500,KIA Picanto,Essence,28 000,2021
+48 000,Ford Fusion Titanium,Essence,217 000,2016
+49 800,Mini 5 portes Très bon état,Essence,160 000,2016
+45 000,BMW Série 3,Essence,180 000,2012
+60 000,Seat Leon 1.2L,Essence,140 000,2018
+200 000,Land Rover Range Rover Sport,Essence,190 000,2015
+89 000,Peugeot 3008 1.2L,Essence,70 000,2020
+87 000,Volkswagen Golf 8,Essence,58 000,2022
+89 000,KIA Sportage 1.6L Diesel,Diesel,105 000,2018
+55 500,Mercedes-Benz Classe C,Essence,235 000,2013
+47 000,Audi Q5 2.0L,Essence,255 000,2009
+139 000,Volkswagen Golf 8,Essence,40 000,2023
+89 000,Mercedes-Benz Classe C AMG,Essence,164 000,2014
+138 000,Mercedes-Benz Classe E 1.6L,Essence,132 000,2017
+108 000,Seat Leon Xcellence,Essence,37 000,2023
+72 000,Jeep Wrangler 4.0L,Essence,200 000,1989
+38 500,Renault Clio 1.0L,Essence,135 000,2021
+78 500,Audi A3 Sportback 1.2L,Essence,125 000,2019
+119 000,Cupra Formentor 1.5L,Hybride,19 000,2022
+55 500,Ford Fusion 1.6,Essence,90 000,2017
+49 500,Mazda 3,Essence,124 000,2017
+39 500,Nissan Juke,Essence,160 000,2015
+227 000,Volvo XC60 2.0L,Essence,18 000,2022
+39 800,Hyundai Grand i10 1.0L,Essence,57 000,2021
+43 000,Skoda Fabia 1.6L,Essence,137 000,2018
+75 000,BMW Série 5 520,Essence,182 000,2014
+93 000,Volkswagen Golf 8 1.5L,Essence,80 000,2021
+132 000,BMW X2 S drive,Essence,74 000,2020
+73 500,Volkswagen Golf 7 Importé,Essence,40 000,2020
+85 000,BMW X1 1.6L,Essence,126 000,2016
+138 500,BMW Série 1 M,Essence,40 000,2022
+58 500,Citroën Berlingo Utilitaire 1.6L,Diesel,31 000,2023
+38 000,Citroën C3,Essence,92 000,2018
+34 500,Citroën C3 Live,Essence,119 000,2019
+38 000,Citroën C4,Essence,109 000,2012
+88 000,Peugeot 3008 Allure,Essence,38 000,2019
+159 000,Mercedes-Benz Classe C Avantgarde,Essence,27 000,2022
+75 000,Peugeot 3008 Allure,Essence,75 000,2020
+139 000,BMW X4,Diesel,140 000,2018
+65 500,Volkswagen Polo R-Line,Essence,70 000,2020
+69 000,Volkswagen Golf 7 BVA,Essence,200 000,2020
+75 000,BMW Série 1 Pack Sport M,Essence,165 000,2016
+147 000,Hyundai Tucson Top Grade,Essence,40 000,2022
+41 000,Lada 4x4 Urban,Essence,58 000,2020
+205 000,Mercedes-Benz Classe X,Diesel,68 000,2020
+81 000,Seat Arona Xperience,Essence,47 000,2022
+69 000,Toyota Corolla Dynamic,Essence,85 000,2020
+65 000,Fiat 500X Pop Star,Essence,60 000,2018
+115 000,Land Rover Discovery,Essence,170 000,2015
+88 000,Haval Jolion,Essence,40 000,2021
+73 000,Toyota C-HR,Essence,130 000,2018
+92 500,Nissan Juke Tekna,Essence,6 000,2024
+Sous leasing                    255 100,Mercedes-Benz Classe C AMG,Essence,20 000,2023
+129 000,Mercedes-Benz CLA Kit Amg 200,Essence,150 000,2020
+62 000,Seat Ibiza Xcellence,Essence,68 000,2021
+57 500,KIA Rio 5p SX,Essence,70 000,2020
+72 000,MG ZS Luxury,Essence,20 000,2022
+101 000,Chery Tiggo 7 Pro,Essence,0,2024
+165 000,Audi Q3 BVA,Essence,3 000,2023
+155 000,Peugeot 408 GT,Essence,10 000,2024
+87 000,Jaguar XF Luxury,Essence,120 000,2014
+85 000,BMW Série 6 Face Lift,Essence,190 000,2009
+189 000,Land Rover Range Rover Sport HSE Dynamic,Diesel,300 000,2016
+62 000,KIA Rio 5p GT-Line,Essence,70 000,2021
+188 000,KIA Sportage GT-Line,Hybride,15 000,2024
+225 000,Mercedes-Benz GLA 250e Pack AMG,Hybride,26 000,2023
+39 000,Mahindra Pick-up SC,Diesel,120 000,2021
+69 000,Peugeot 3008,Essence,112 000,2020
+73 000,KIA Rio 5p GT-Line,Essence,9 000,2023
+152 000,Mercedes-Benz Classe C Pack AMG Pack night,Hybride,120 000,2019
+89 000,Peugeot 3008 GT GT-line,Essence,125 000,2020
+77 900,MG HS Luxury,Essence,87 000,2020
+173 000,Mercedes-Benz GLA AMG,Essence,90 000,2021
+87 000,BMW Série 4 Coupé 420i,Essence,180 000,2015
+88 000,Chery Tiggo 7 Pro,Essence,40 000,2022
+98 000,Suzuki Jimny,Essence,20 000,2023
+83 000,Mercedes-Benz CLA Kit AMG,Essence,124 000,2014
+37 500,Citroën C3 Shine,Essence,88 000,2018
+63 000,Mercedes-Benz Classe C coupé AMG,Essence,200 000,2012
+45 000,Renault Clio 4,Essence,120 000,2021
+29 000,Mini 3 portes One,Essence,200 000,2009
+129 000,Hyundai Tucson High Grade,Essence,19 000,2023
+87 000,Nissan Juke Tekna,Essence,53 000,2021
+88 000,Jeep Renegade,Essence,88 000,2021
+152 000,Mercedes-Benz Classe C AMG,Hybride,120 000,2019
+109 000,Ford Mondeo Hybride,Hybride,34 000,2020
+120 000,Land Rover Range Rover Evoque,Diesel,145 000,2018
+59 000,Volkswagen Passat,Essence,160 000,2016
+117 000,Haval H6,Essence,16 000,2022
+85 000,Haval H6 Luxury,Essence,55 000,2021
+105 000,Volkswagen Golf 8 1.4,Essence,40 000,2022
+179 000,Jaguar F-Pace R_Dynamic,Diesel,165 000,2017
+70 000,Renault Kadjar,Essence,140 000,2018
+79 000,Toyota Corolla,Essence,24 000,2022
+47 000,Peugeot 308,Essence,128 000,2020
+167 000,Mercedes-Benz Classe C coupé AMG,Essence,130 000,2018
+47 500,Citroën C3 Shine,Essence,45 000,2020
+40 000,Ford Focus Titanium,Essence,200 000,2015
+178 000,Porsche Panamera,Essence,82 000,2011
+89 000,KIA Seltos,Essence,130 000,2021
+81 000,Seat Ibiza FR,Essence,40 000,2023
+77 000,Alfa Romeo Giulietta,Essence,37 000,2019
+235 000,Land Rover Discovery R-DYNAMIC,Diesel,87 000,2020
+49 000,Volkswagen Golf 7 Confortline,Essence,190 000,2013
+64 500,Renault Megane 4 Diesel,Diesel,125 000,2020
+65 000,KIA Rio 5p GT-Line,Essence,60 000,2021
+35 000,Fiat Fiorino,Diesel,120 000,2021
+75 000,Dacia Duster Techroad,Essence,35 000,2020
+278 000,BMW Série 5 530e Xdrive Pack m,Hybride,50 000,2021
+97 000,BMW Série 4 Gran Coupé 418 Luxury,Essence,133 000,2016
+125 000,Volkswagen Passat R-Line DSG,Essence,40 000,2022
+290 000,Toyota Hilux Double Cabine Gr Sport,Diesel,7 000,2024
+91 000,Toyota C-HR,Essence,55 000,2022
+109 000,Audi A5 Sportback S-Line,Essence,120 000,2019
+80 000,Peugeot 2008,Diesel,100 000,2021
+Sous leasing                    59 700,KIA Rio 5p,Essence,85 000,2022
+91 000,Honda CR-V,Essence,67 000,2018
+295 000,Audi Q5 S-line,Diesel,40 000,2021
+107 000,KIA Sportage Hybride,Hybride,114 000,2021
+128 000,KIA Sportage GT-Line,Diesel,19 000,2021
+76 000,Dacia Duster Techroad,Essence,34 000,2020
+660 000,Mercedes-Benz Classe S AMG,Hybride,3 000,2022
+455 000,BMW X5 Hybride Xdrive E45,Hybride,19 000,2021
+138 000,Hyundai Tucson Hybride Xcellence,Hybride,120 000,2022
+75 000,BMW Série 1 I Pack Sport,Essence,200 000,2019
+105 000,KIA Sportage GT-Line,Diesel,140 000,2017
+235 000,Mercedes-Benz Classe C AMG,Essence,50 000,2023
+120 000,Jaguar XE,Diesel,140 000,2017
+72 000,Peugeot Rifter,Diesel,95 000,2020
+110 000,BMW Série 7 740LI,Essence,98 000,2010
+72 000,Peugeot Rifter 5 places,Diesel,95 000,2020
+187 000,Land Rover Range Rover Evoque Hybride,Diesel,50 000,2019
+115 000,Ford Mondeo Hybride,Hybride,32 000,2020
+64 000,KIA Rio 5p GT-Line,Essence,64 000,2021
+169 000,Mercedes-Benz GLC AMG,Essence,115 000,2017
+57 000,Mini 5 portes One,Essence,78 000,2016
+48 000,Citroën C3 Shine,Essence,28 000,2020
+85 000,Audi A3 Berline,Essence,50 000,2019
+83 500,KIA Sportage,Essence,127 000,2019
+Non dédouané                    235 000,Mercedes-Benz GLA AMG,Essence,12 000,2023
+95 000,Audi Q3,Essence,95 000,2017
+210 000,Mercedes-Benz GLB 200 d,Diesel,111 000,2021
+58 000,Audi A4 Face_lift,Essence,143 000,2016
+95 000,Land Rover Range Rover Evoque Face_lift,Essence,170 000,2016
+135 000,BMW Série 1 Pack M,Essence,40 000,2020
+195 000,Land Rover Range Rover Evoque Hybride,Diesel,40 000,2019
+79 000,Haval H6 Luxury,Essence,120 000,2020
+105 000,Iveco Daily Simple Cabine,Diesel,40 000,2022
+128 000,Land Rover Discovery Sport,Diesel,128 000,2017
+90 000,Haval H6 Luxury,Essence,40 000,2021
+98 000,KIA Sportage Hybride,Hybride,140 000,2020
+85 000,KIA Sportage,Essence,125 000,2019
+137 000,Hyundai Tucson Hybride,Hybride,80 000,2021
+165 000,Audi Q5 QUATTRO 40 TDI,Diesel,170 000,2019
+43 500,Fiat Panda City Cross,Essence,52 000,2020
+45 000,Volkswagen Golf 6 Match,Diesel,240 000,2012
+228 000,Ford Ranger Raptor,Diesel,100 000,2022
+130 000,BMW Série 4 Coupé Pack M,Essence,140 000,2021
+48 000,Mercedes-Benz Classe B,Essence,100 000,2014
+75 000,MG ZS Luxury,Essence,80 000,2022
+210 000,Land Rover Range Rover Evoque Hybride,Diesel,60 000,2019
+68 000,Renault Kadjar,Essence,70 000,2019
+56 000,Mazda 3 Sky active,Essence,103 000,2017
+398 000,Audi Q8 S_Line,Essence,16 000,2021
+173 000,Mercedes-Benz Classe C coupé AMG,Essence,50 000,2019
+Sous leasing                    78 000,MG ZS,Essence,35 000,2022
+40 000,Suzuki Baleno,Essence,160 000,2017
+95 000,KIA Sportage,Essence,69 000,2019
+69 000,Ford Kuga,Essence,100 000,2017
+119 000,Mercedes-Benz CLS AMG,Diesel,160 000,2011
+185 000,Mercedes-Benz GLA 180 Pack AMG,Essence,40 000,2022
+73 500,Seat Arona,Essence,26 000,2021
+71 000,Toyota Corolla,Essence,90 000,2021
+79 000,Haval H6 Luxury,Essence,115 000,2020
+125 000,Skoda Superb Ambassador,Essence,30 000,2021
+79 000,MG 6,Essence,22 000,2021
+189 000,Mercedes-Benz GLC Coupé AMG,Diesel,190 000,2017
+89 000,Mercedes-Benz Classe C 180 elegance,Essence,170 000,2016
+278 000,Mercedes-Benz GLC Coupé AMG,Hybride,69 000,2020
+135 000,Mercedes-Benz Classe E 180,Essence,90 000,2018
+42 000,Ssangyong Actyon Sports,Diesel,200 000,2017
+35 000,DS 3,Essence,138 000,2012
+97 000,Audi A3 Berline,Essence,17 000,2020
+43 000,Nissan Qashqai,Essence,147 000,2011
+90 000,BMW Série 5 Confort Luxury,Essence,200 000,2015
+101 000,Volkswagen Passat R-Line,Essence,100 000,2019
+125 000,Land Rover Discovery Sport,Diesel,160 000,2017
+44 500,Citroën C3 Shine,Essence,90 000,2019
+49 000,Volkswagen Amarok,Diesel,370 000,2012
+Sous leasing                    291 800,Mercedes-Benz Classe E Business,Essence,8 000,2022
+37 000,Mini 3 portes one,Essence,140 000,2013
+68 000,BMW Série 1,Essence,126 000,2017
+231 000,Toyota Hilux Double Cabine 4*4,Essence,3 000,2024
+97 000,Peugeot 2008 Allure,Essence,34 000,2022
+158 000,Mercedes-Benz Classe A AMG,Essence,20 000,2022
+106 000,Volkswagen Passat R-Line,Essence,60 000,2020
+90 000,Volkswagen Tiguan,Essence,60 000,2018
+99 000,Mercedes-Benz Classe C AMG,Essence,160 000,2014
+96 000,Chery Tiggo 8 Pro,Essence,80 000,2022
+47 000,BYD F3,Essence,10 000,2022
+44 500,Citroën C3 Shine,Essence,58 000,2019
+107 000,BMW Série 4 Coupé 420i Pack M,Essence,160 000,2015
+90 000,Audi Q3 S-line,Essence,100 000,2017
+109 000,Volkswagen Golf 8 United,Essence,26 000,2020
+35 000,Peugeot 208,Essence,60 000,2020
+59 000,Audi A5 Cabriolet S-line,Essence,120 000,2010
+135 000,Honda Accord,Essence,11 000,2022
+74 000,Volkswagen Golf 7,Essence,40 000,2019
+119 000,KIA Sportage,Essence,40 000,2020
+135 000,BMW Série 2 Gran Coupé 218i,Essence,21 000,2022
+46 000,Fiat Tipo 5 portes,Essence,75 000,2018
+Sous leasing                    150 600,Haval H6,Essence,13 000,2022
+52 000,Volkswagen Golf 7 Smartline,Essence,140 000,2015
+78 000,Haval H6 Luxury,Essence,90 000,2019
+40 000,Chevrolet Cruze,Essence,90 000,2018
+76 000,Volkswagen Golf 7,Essence,29 000,2019
+51 000,Mercedes-Benz Classe E 200,Essence,330 000,2010
+77 000,Mercedes-Benz Classe E e220,Diesel,330 000,2011
+145 000,Volkswagen Golf 8 R-Line,Essence,40 000,2021
+240 000,Mercedes-Benz Classe C AMG,Essence,16 000,2023
+Non dédouané                    212 000,Dodge RAM Rumble bee,Essence,65 000,2019
+81 000,Mercedes-Benz CLA,Essence,163 000,2014
+69 000,Haval H2 Luxury,Essence,40 000,2019
+86 000,Haval H6 Luxury,Essence,32 000,2019
+169 000,Mercedes-Benz CLA AMG,Essence,30 000,2021
+98 000,Mercedes-Benz Classe A 180d,Diesel,50 000,2019
+74 000,Volkswagen Golf 7,Essence,64 000,2019
+95 000,Audi A3 Sportback S-Line,Essence,70 000,2019
+205 000,Mercedes-Benz Classe C AMG,Essence,40 000,2022
+105 000,DS 7 Crossback Grand Chic,Essence,140 000,2021
+Sous leasing                    264 200,Mercedes-Benz Classe C AMG,Essence,50 000,2022
+84 000,Volkswagen Golf 7 Join,Essence,70 000,2018
+79 000,Mercedes-Benz CLA 220,Diesel,240 000,2013
+110 000,BMW X6 Pack M,Diesel,270 000,2008
+59 000,Audi A5 Cabriolet S-line,Essence,120 000,2010
+73 000,Seat Leon Style,Essence,65 000,2020
+37 500,Citroën Berlingo Utilitaire,Diesel,170 000,2018
+143 000,KIA Sportage,Essence,23 000,2022
+64 000,Volkswagen Golf 7,Essence,180 000,2019
+78 000,Mercedes-Benz Classe S Executive,Essence,170 000,2008
+128 000,Volkswagen Tiguan Confortline,Essence,33 000,2020
+80 000,Volkswagen Golf 7 R-Line,Essence,130 000,2018
+79 000,Hyundai Kona,Hybride,30 000,2021
+Sous leasing                    122 800,Seat Leon FR,Essence,70 000,2022
+53 000,Hyundai Grand i10,Essence,30 000,2022
+92 000,Peugeot 2008 GT_LINE,Essence,30 000,2021
+179 000,Mercedes-Benz Classe C coupé AMG,Essence,40 000,2019
+119 000,KIA Sportage GT-Line,Hybride,120 000,2021
+88 000,BMW Série 3 318i,Essence,117 000,2017
+43 500,Chery Tiggo 2 Confort,Essence,60 000,2020
+87 000,Haval Jolion,Essence,40 000,2022
+208 000,Mercedes-Benz Classe C AMG,Essence,40 000,2022
+53 000,Hyundai Grand i10,Essence,54 000,2021
+68 000,Seat Ibiza FR,Essence,100 000,2020
+169 000,Mercedes-Benz CLA AMG,Essence,20 000,2020
+67 000,Seat Ibiza FR,Essence,50 000,2020
+85 000,Volkswagen T-roc,Essence,87 000,2020
+113 000,Mercedes-Benz GLA AMG,Essence,74 000,2016
+115 000,Mercedes-Benz Classe C AMG,Essence,170 000,2014
+188 000,Audi Q3 Sportback,Essence,10 000,2021
+215 000,Audi Q5,Diesel,100 000,2018
+125 000,Volkswagen Golf 8 R-Line,Essence,70 000,2021
+185 000,Jaguar F-Pace R-DYNAMIC,Diesel,165 000,2017
+77 000,Peugeot 3008 GT-line,Essence,260 000,2017
+Non dédouané                    350 000,Land Rover Range Rover Velar R-Dynamic,Diesel,100 000,2019
+255 000,Porsche Panamera PLATINUM édition,Essence,100 000,2014
+295 000,Land Rover Range Rover Velar R-Dynamic,Essence,90 000,2020
+Sous leasing                    182 900,Dongfeng Forthing T5 EVO,Essence,4 000,2023
+47 000,Chery Tiggo 3,Essence,75 000,2018
+85 000,Audi Q3,Essence,77 000,2017
+66 000,Renault Kadjar Intens,Essence,150 000,2018
+155 000,Volkswagen Golf 8 R-Line,Essence,40 000,2021
+205 000,Mercedes-Benz Classe C AMG,Hybride,35 000,2020
+80 000,Volkswagen Golf 7 Join,Essence,120 000,2019
+99 000,BMW Série 4 Gran Coupé Luxury,Essence,100 000,2018
+161 000,Hyundai Tucson,Essence,24 000,2023
+87 000,Hyundai Tucson,Essence,120 000,2020
+92 000,BMW Série 1 Pack sport,Essence,70 000,2020
+45 000,Fiat Panda City Cross,Essence,20 000,2022
+125 000,BMW Série 4 Gran Coupé 418 PACK M,Essence,110 000,2017
+77 000,Mercedes-Benz Classe E AMG,Essence,135 000,2011
+215 000,Mercedes-Benz Classe C AMG,Essence,80 000,2022
+65 000,Dongfeng SX3,Essence,30 000,2021
+128 000,Volkswagen Golf 8 United,Essence,16 000,2021
+172 000,Mercedes-Benz Classe A AMG,Essence,15 000,2022
+148 000,Mercedes-Benz Classe C AMG,Diesel,80 000,2019
+62 000,MG GS Luxe,Essence,115 000,2017
+Sous leasing                    122 800,Mitsubishi ASX 4WD,Essence,55 000,2021
+126 000,Land Rover Discovery,Diesel,130 000,2017
+185 000,Audi A5 Sportback,Essence,70 000,2021
+45 000,BMW Série 7 Individuel,Essence,300 000,2008
+245 000,Land Rover Range Rover Sport,Diesel,160 000,2014
+110 000,BMW Série 4 Coupé,Essence,78 000,2017
+61 000,MG GS Luxe Plus,Essence,100 000,2017
+40 000,Peugeot RCZ,Essence,171 000,2011
+118 000,Land Rover Discovery Sport,Diesel,94 000,2016
+87 000,Volkswagen Amarok AWD,Diesel,180 000,2016
+55 000,BMW Série 7 740I FACE-LIFT,Essence,220 000,2008
+69 000,Ford Ecosport Titanium,Essence,67 000,2022
+120 000,Toyota Corolla Cross Hybride High,Hybride,36 000,2022
+58 000,MG ZS Confort Plus,Essence,141 000,2019
+85 000,KIA Sportage,Essence,150 000,2019
+74 000,BMW Série 3 coupé Kit M///,Essence,152 000,2012
+71 000,Mercedes-Benz Classe C AMG,Essence,200 000,2011
+75 000,Audi A5 Coupé,Essence,109 000,2014
+58 500,KIA Rio 5p SX,Essence,35 000,2020
+36 500,BMW Série 1 Business Line,Essence,251 000,2012
+78 000,Volkswagen Golf 7 Sound,Essence,125 000,2018
+170 000,Mercedes-Benz CLA AMG,Hybride,25 000,2021
+135 000,Mercedes-Benz Classe A AMG,Hybride,35 000,2020
+50 000,Peugeot 308,Essence,102 000,2020
+67 000,Ford Ecosport Titanium,Essence,44 000,2022
+62 000,Fiat 500 Cult Club,Essence,3 000,2023
+115 000,Mercedes-Benz Classe A AMG,Essence,60 000,2021
+110 000,Volkswagen Tiguan R-Line,Essence,160 000,2019
+40 000,Volkswagen Scirocco,Essence,200 000,2010
+115 000,Audi A5 Sportback,Essence,80 000,2019
+100 000,Hyundai Tucson,Diesel,81 000,2018
+125 000,Land Rover Discovery,Essence,110 000,2016
+110 000,Mercedes-Benz Classe A,Essence,90 000,2021
+178 000,Hyundai Tucson Hybride Top Grade,Diesel,16 000,2023
+51 000,Peugeot 508,Essence,145 000,2018
+145 000,Mercedes-Benz Classe C coupé AMG,Essence,120 000,2019
+230 000,Land Rover Range Rover Sport,Diesel,90 000,2017
+220 000,Porsche Cayenne,Essence,158 000,2015
+67 000,BMW Série 3,Essence,210 000,2015
+108 000,Mercedes-Benz Classe A,Essence,50 000,2020
+66 000,Mercedes-Benz Classe C,Essence,180 000,2013
+83 000,Renault Kadjar,Essence,98 000,2021
+85 000,Land Rover Range Rover Sport,Diesel,208 000,2007
+200 000,Audi Q3,Hybride,40 000,2023
+95 000,KIA Sorento,Diesel,120 000,2016
+118 000,KIA Sportage,Diesel,140 000,2018
+53 000,KIA Rio 5p SX PLUS,Essence,99 000,2020
+Sous leasing                    47 100,Wallyscar 719,Essence,86 573,2023
+61 000,Renault Megane Sedan,Essence,46 000,2019
+78 000,Ford Ecosport,Essence,19 000,2022
+58 000,Mercedes-Benz ML,Diesel,250 000,2007
+36 000,Ford Focus Trend Sport,Essence,180 000,2014
+65 000,Toyota Prado Adventure,Diesel,330 000,1999
+27 500,Peugeot 207 Access Plus,Diesel,290 000,2011
+145 000,Mercedes-Benz CLA,Diesel,60 000,2021
+63 500,Hyundai ix35 Toit Panoramique,Diesel,160 000,2016
+41 300,Volkswagen Polo Sedan Trendline,Essence,170 000,2020
+68 500,Mercedes-Benz Classe A AMG,Essence,180 000,2014
+420 000,Mercedes-Benz GLC Coupé AMG,Essence,0,2024
+105 000,Mercedes-Benz Classe C,Essence,200 000,2014
+65 000,Ssangyong Tivoli Confort Plus,Essence,4 700,2018
+63 000,Mini 3 portes John Cooper Works,Essence,100 000,2017
+168 000,Toyota Hilux Double Cabine D4D,Diesel,140 000,2020
+255 000,Land Rover Range Rover Evoque HSE,Hybride,60 000,2022
+132 000,Mercedes-Benz Classe A Berline AMG,Essence,100 000,2020
+385 000,Land Rover Range Rover Sport Autobiography,Hybride,60 000,2021
+220 000,Mercedes-Benz CLA AMG,Essence,0,2024
+480 000,Porsche Cayenne Coupé GTS,Hybride,70 000,2020
+450 000,Mercedes-Benz GLE Coupé,Hybride,30 000,2022
+260 000,Mercedes-Benz Classe E AMG,Hybride,70 000,2020
+270 000,Mercedes-Benz GLC Coupé AMG,Hybride,80 000,2021
+145 000,BMW Série 4 Gran Coupé KIT-M-individual,Essence,120 000,2016
+115 000,Mercedes-Benz CLA,Diesel,130 000,2017
+145 000,Audi A3 Sportback 1.5,Hybride,900,2023
+190 000,Tesla Model 3 Modèle 3 Highland 2024,Electrique,15 000,2023
+197 000,Mercedes-Benz GLC AMG,Hybride,130 000,2018
+168 000,Mercedes-Benz Classe E,Diesel,158 000,2020
+56 000,Nissan Qashqai,Diesel,147 000,2016
+145 000,Hyundai Tucson,Essence,37 000,2022
+95 000,Audi Q2 Design,Essence,77 000,2019
+62 000,KIA Rio 5p,Essence,51 000,2021
+85 000,Toyota C-HR,Essence,71 000,2021
+78 000,KIA Sportage Black Edition,Essence,117 000,2018
+26 000,Mahindra KUV 100 K6+,Essence,90 000,2021
+75 000,Toyota C-HR,Essence,165 000,2020
+28 000,Ford Fiesta Trend,Essence,161 000,2013
+150 000,BMW Série 4 Coupé M,Essence,85 000,2019
+60 000,Renault Megane Sedan,Essence,70 000,2021
+104 000,Mazda CX-9 High grade,Essence,155 000,2019
+29 500,Ford Fiesta Titanium,Essence,223 000,2013
+26 000,Peugeot Partner,Diesel,320 000,2009
+37 900,Suzuki Celerio,Essence,45 000,2022
+144 900,Mercedes-Benz CLA AMG,Essence,100 000,2020
+90 000,MG HS Trophy,Essence,111 000,2022
+41 500,Seat Ibiza,Essence,83 000,2019
+48 000,Ssangyong Tivoli,Essence,235 000,2018
+32 500,Mahindra KUV 100 K6+,Essence,59 000,2022
+18 000,Hyundai H-1,Essence,999 999,2006
+"29,500 DT",Nissan Micra,Essence,"130,000 KM",2017
+"28,600 DT",BMW Serie 1,Essence,"240,000 KM",2007
+0 DT,Suzuki Swift,Essence,"91,000 KM",2021
+0 DT,Skoda Fabia,Essence,"78,000 KM",2021
+0 DT,Kia Optima,Essence,"247,000 KM",2014
+"25,800 DT",Fiat Doblo,Diesel,"160,000 KM",2020
+"78,000 DT",Mercedes-Benz Classe C,Essence,"207,600 KM",2014
+"39,500 DT",Kia Cerato,Essence,"14,400 KM",2015
+"55,500 DT",Kia Rio,Essence,"90,000 KM",2021
+0 DT,Citroen Berlingo,Diesel,"181,000 KM",2019
+0 DT,Renault Megane,Diesel,"149,000 KM",2020
+"44,500 DT",Volkswagen Polo,Essence,"140,000 KM",2021
+"30,500 DT",Renault Clio,Essence,"116,000 KM",2012
+950 DT,Citroen C5,Essence,250 KM,2024
+0 DT,Chevrolet S-10,Essence,"64,000 KM",2021
+0 DT,Renault Clio,Essence,"67,000 KM",2021
+"17,500 DT",Peugeot 207,Essence,"229,999 KM",2012
+0 DT,Mercedes-Benz Classe A,Essence,"48,000 KM",2019
+"20,000 DT",Citroen Nemo,Diesel,"420,000 KM",2014
+"13,500 DT",Peugeot 306,Essence,"202,000 KM",2000
+0 DT,Fiat Tipo,Diesel,"113,167 KM",2020
+"34,000 DT",Citroen C3,Essence,"97,000 KM",2018
+"29,000 DT",SsangYong Actyon,Diesel,"424,000 KM",2015
+0 DT,Volkswagen Polo,Essence,"84,200 KM",2021
+0 DT,Suzuki Celerio,Essence,"58,000 KM",2021
+"9,000 DT",Opel Corsa,Essence,312 KM,N.C
+"1,111 DT",Volkswagen Golf 5,Essence,"170,000 KM",2007
+"66,500 DT",Peugeot 3008,Essence,"100,000 KM",2019
+0 DT,Mercedes-Benz Classe A,N.C,"32,000 KM",2021
+"78,000 DT",Peugeot Partner,Diesel,"70,000 KM",2020
+0 DT,Kia Sportage,Diesel,"139,000 KM",2018
+"41,500 DT",Skoda Fabia,Essence,"130,000 KM",2021
+0 DT,Toyota Corolla,Essence,"31,000 KM",2021
+0 DT,Mercedes-Benz Classe C,N.C,"26,000 KM",2022
+0 DT,Haval H6,Essence,"15,000 KM",2022
+0 DT,Renault Clio,Essence,"95,000 KM",2020
+"105,000 DT",BMW Serie 4,Essence,"150,000 KM",2019
+"152,000 DT",BMW X4,Essence,"62,000 KM",2016
+0 DT,Mercedes-Benz Classe A,Essence,"48,000 KM",2020
+0 DT,Volkswagen Golf,Essence,"190,000 KM",2012
+0 DT,BMW Serie 5,Essence,"140,000 KM",2017
+"53,000 DT",Fiat Tipo,Essence,"113,000 KM",2020
+0 DT,Renault Clio,Diesel,N.C,2021
+0 DT,Volkswagen Passat CC,Essence,"111,000 KM",2019
+0 DT,Volkswagen Golf 8,Essence,"38,000 KM",2021
+0 DT,Volkswagen Golf 7,Essence,"81,000 KM",2018
+0 DT,Volkswagen Golf 7,Essence,"71,000 KM",2019
+0 DT,Peugeot 208,Essence,"65,000 KM",2020
+0 DT,Volkswagen Passat,N.C,"50,000 KM",2020
+"48,500 DT",Renault Megane,Essence,"150,000 KM",2020
+0 DT,Renault Clio,Essence,"241,000 KM",2008
+"79,000 DT",Ford Focus,Essence,"60,000 KM",2020
+"82,000 DT",Nissan Juke,Essence,"27,000 KM",2023
+0 DT,Peugeot Partner,Diesel,"119,000 KM",2021
+0 DT,Mitsubishi L200,Diesel,"205,000 KM",2017
+"44,000 DT",Peugeot 2008,Essence,"117,000 KM",2018
+"33,800 DT",Nissan Micra,Essence,"74,300 KM",2020
+0 DT,SEAT Ibiza,Essence,N.C,2014
+"67,000 DT",Mercedes-Benz Classe E,Essence,"197,000 KM",2010
+"55,000 DT",Audi A6,Essence,"166,920 KM",2016
+"41,000 DT",Hyundai i10,Essence,"65,000 KM",2023
+0 DT,Volkswagen Golf 8,N.C,"69,000 KM",2021
+0 DT,Alfa Romeo Giulietta,Essence,"143,000 KM",2015
+0 DT,Volkswagen Passat,Essence,"128,000 KM",2010
+"96,000 DT",Kia Sportage,Essence,"45,000 KM",N.C
+0 DT,Fiat Linea,Essence,"167,000 KM",2009
+"1,111 DT",Jeep Compass,Essence,"64,000 KM",2020
+"1,111 DT",BMW Serie 4,Essence,"150,000 KM",2019
+"1,111 DT",Land Rover Range Rover Sport,Hybride,"42,000 KM",2020
+0 DT,Porsche Cayenne,Essence,"10,000 KM",2015
+0 DT,Mercedes-Benz Classe A,Essence,"89,000 KM",2020
+0 DT,Renault Captur,N.C,"90,000 KM",2022
+"38,500 DT",Fiat Panda,Essence,"130,000 KM",2022
+"42,000 DT",Ford Focus,Essence,"120,000 KM",2016
+0 DT,Fiat Siena,Essence,"200,000 KM",2006
+"75,000 DT",Kia Sportage,Essence,"160,000 KM",2017
+"45,500 DT",Fiat 500C,Essence,"71,000 KM",2017
+0 DT,Dacia Dokker,Diesel,"127,000 KM",2021
+0 DT,Peugeot 308,Diesel,"208,000 KM",2011
+0 DT,Hyundai Tucson,Essence,N.C,2008
+0 DT,Volkswagen Golf,Diesel,"182,000 KM",2012
+0 DT,Volkswagen Golf,Diesel,"134,000 KM",2020
+"61,500 DT",Citroen DS5,Essence,"110,000 KM",2017
+0 DT,Renault Clio,Essence,"90,000 KM",2019
+"42,000 DT",Citroen C3,Essence,"98,270 KM",2018
+0 DT,SEAT Ibiza,Essence,"48,000 KM",2019
+"117,000 DT",Kia Sportage,N.C,"54,000 KM",2020
+"58,000 DT",Volkswagen Passat,Essence,"140,000 KM",2016
+"54,000 DT",Peugeot 2008,Essence,"90,000 KM",2019
+"22,800 DT",Chery QQ,Essence,"104,000 KM",2019
+"45,500 DT",Peugeot 208,Essence,"78,000 KM",2021
+"78,000 DT",Audi A3,Essence,"98,000 KM",2020
+"13,500 DT",Opel Corsa,Essence,"266,000 KM",2000
+"70,000 DT",SEAT Leon,Essence,"61,847 KM",2019
+0 DT,Mercedes-Benz Classe CLA,N.C,"27,000 KM",2022
+"35,500 DT",Citroen C3,Essence,"58,000 KM",2021
+"46,500 DT",Kia Picanto,Essence,"28,000 KM",2021
+0 DT,Volkswagen Polo,Essence,"81,000 KM",2022
+"90,000 DT",MG ZS,Essence,13 KM,2024
+"47,000 DT",Nissan Navara,Diesel,"315,000 KM",2012
+0 DT,Ford Fiesta,Essence,"197,000 KM",2010
+0 DT,Toyota Aygo,Essence,"60,000 KM",2017
+0 DT,Mercedes-Benz 220,Diesel,"250,000 KM",2002
+0 DT,SEAT Ibiza,Essence,"106,000 KM",2021
+0 DT,Volkswagen Golf,Essence,"80,000 KM",2018
+0 DT,Kia Sportage,Diesel,"24,000 KM",2017
+0 DT,Peugeot Partner,Diesel,"105,000 KM",2020
+0 DT,Audi A3,Diesel,"210,000 KM",2010
+"30,000 DT",Peugeot 508,Essence,"268,000 KM",2012
+"40,500 DT",Renault Clio,Essence,"110,000 KM",2016
+0 DT,Mercedes-Benz Classe A,Essence,"68,653 KM",2018
+0 DT,BMW Serie 5,Diesel,"287,586 KM",2007
+0 DT,Hyundai Grand i10,Essence,"94,260 KM",2017
+0 DT,Kia Sportage,Diesel,"207,991 KM",2018
+"19,500 DT",Renault Megane,Diesel,"350,000 KM",2007
+0 DT,Peugeot 308,Essence,"36,799 KM",2021
+"48,500 DT",Kia Rio,Essence,"170,000 KM",2021
+"42,500 DT",Renault Clio,Essence,"80,000 KM",2021
+0 DT,Toyota Hilux,Diesel,N.C,2018
+0 DT,Kia Sportage,Essence,"150,000 KM",2019
+0 DT,Renault Kadjar,Essence,"60,000 KM",2023
+"8,500 DT",Renault Clio,Essence,"300,000 KM",1993
+0 DT,Volkswagen Polo,Essence,"189,000 KM",2012
+400 DT,Renault Clio,Essence,N.C,2023
+0 DT,Citroen C3,Diesel,"92,000 KM",2020
+0 DT,Mercedes-Benz Classe E,Essence,"95,000 KM",2017
+0 DT,Fiat Doblo,Diesel,"165,000 KM",2017
+"36,500 DT",Citroen C-Elysee,Essence,"70,000 KM",2020
+0 DT,Renault Clio,Essence,"150,000 KM",2006
+"52,000 DT",Volkswagen Polo,Essence,N.C,2022
+"120,000 DT",Mazda BT-50,Essence,"190,000 KM",2015
+0 DT,Audi A4,Essence,"44,000 KM",2018
+"26,000 DT",Nissan Micra,Essence,"160,000 KM",2013
+0 DT,Citroen Berlingo,Diesel,"190,000 KM",2016
+0 DT,Peugeot Partner,Diesel,"140,000 KM",2020
+"61,500 DT",Kia Rio,Essence,"48,000 KM",2024
+"12,800 DT",Opel Corsa,Essence,"350,000 KM",2000
+0 DT,Renault Clio,Essence,"150,000 KM",2014
+0 DT,Suzuki Celerio,Essence,"50,000 KM",2023
+0 DT,Volkswagen Polo,Essence,"190,000 KM",2017
+0 DT,Mahindra Hover,Essence,"2,000 KM",2024
+0 DT,Dacia Logan MCV,Essence,"20,000 KM",2023
+0 DT,Renault Symbol,Essence,"120,000 KM",2012
+"46,000 DT",Mazda CX-9,Essence,"286,000 KM",2010
+0 DT,Volkswagen Golf,Diesel,"203,588 KM",2012
+0 DT,Peugeot 208,Essence,"112,223 KM",2017
+0 DT,Renault Symbol,Essence,"195,000 KM",2011
+"41,000 DT",Renault Clio,Essence,"91,300 KM",2020
+"61,000 DT",SsangYong Tivoli,Essence,"74,000 KM",2020
+"77,500 DT",Mercedes-Benz Classe CLA,Essence,"170,000 KM",2014
+"67,500 DT",BMW X5,Diesel,"280,000 KM",2008
+"40,900 DT",Toyota Aygo,Essence,"90,000 KM",2021
+"9,000 DT",Peugeot 205,Essence,"111,000 KM",1993
+"27,500 DT",Peugeot 207,Diesel,"290,000 KM",2011
+0 DT,BMW Serie 1,Essence,"144,000 KM",2015
+0 DT,Kia Sportage,N.C,"100,000 KM",2020
+0 DT,Volkswagen Polo,Essence,"116,000 KM",2021
+0 DT,Hyundai Grand i10,Essence,"90,000 KM",2021
+"1,000 DT",Renault R4,Essence,"57,000 KM",1980
+"10,000 DT",Renault Clio,Essence,"123,000 KM",2005
+"190,000 DT",Hyundai Santa Fe,Diesel,"48,000 KM",2020
+0 DT,Mazda 6,Essence,"157,000 KM",2018
+"19,000 DT",Peugeot 206,Essence,N.C,2001
+"32,000 DT",Fiat Fiorino,Diesel,"112,000 KM",2019
+0 DT,Citroen C3,Essence,"81,000 KM",2021
+"173,000 DT",Mercedes-Benz Classe C,Essence,"9,000 KM",2021
+0 DT,Volkswagen Golf,Essence,"130,000 KM",2015
+"27,000 DT",Chevrolet Spark,Essence,"121,000 KM",2015
+"35,000 DT",Peugeot 308,Essence,"168,000 KM",2015
+"37,000 DT",SEAT Ibiza,Essence,"205,000 KM",2020
+0 DT,Volkswagen Polo,Essence,"80,000 KM",2021
+"51,500 DT",Hyundai i20,Essence,"72,000 KM",2022
+"19,700 DT",Citroen C3,Essence,"195,540 KM",2007
+"85,000 DT",Toyota C-HR,Essence,"711,000 KM",2021
+"25,000 DT",Volkswagen Polo,Essence,"47,000 KM",2006
+"33,000 DT",Hyundai i10,Essence,"88,000 KM",2018
+0 DT,Mazda BT-50,Diesel,N.C,2009
+"38,500 DT",Citroen Berlingo,Diesel,"76,470 KM",2015
+0 DT,Peugeot 208,Essence,"48,000 KM",2022
+"220,000 DT",Mercedes-Benz Classe A,Essence,"10,000 KM",2002
+"64,000 DT",Volkswagen Caddy,Diesel,"124,000 KM",2020
+"33,000 DT",Peugeot Partner,Diesel,"282,000 KM",2016
+0 DT,Mercedes-Benz Classe B,Essence,"226,000 KM",2009
+"65,000 DT",BMW X5,Essence,"154,000 KM",2009
+"30,000 DT",Peugeot 208,Essence,"113,000 KM",2017
+"56,000 DT",Volkswagen Passat,Diesel,"300,000 KM",2013
+0 DT,Nissan Micra,Essence,"190,000 KM",2018
+0 DT,Renault Megane,Diesel,"2,021 KM",2021
+0 DT,Citroen Berlingo,Diesel,"95,000 KM",2020
+0 DT,BMW Serie 1,Essence,"185,000 KM",2016
+0 DT,Kia Picanto,Essence,"30,000 KM",2022
+0 DT,Dacia Sandero,Essence,"78,000 KM",2021
+0 DT,Peugeot 208,Essence,"28,000 KM",2023
+"75,000 DT",Toyota C-HR,Essence,"165,000 KM",2020
+0 DT,Suzuki Celerio,Essence,"70,000 KM",2021
+"60,000 DT",Renault Megane,Essence,"60,000 KM",2021
+"25,000 DT",Mercedes-Benz Classe A,Essence,"100,000 KM",2002
+"8,000 DT",Peugeot 206,Diesel,N.C,2003
+0 DT,Volkswagen Golf 8,Essence,"60,000 KM",2021
+"22,000 DT",Peugeot 301,Essence,"106,000 KM",2014
+"24,500 DT",Peugeot 301,Essence,"170,000 KM",2015
+0 DT,Citroen Nemo,Diesel,"232,000 KM",2018
+0 DT,Volkswagen Golf 4,Essence,"298,000 KM",2000
+"42,500 DT",Suzuki Swift,Essence,"49,500 KM",2019
+"42,300 DT",Kia Picanto,Essence,"74,000 KM",2020
+0 DT,Renault Clio,Essence,231 KM,N.C
+"40,000 DT",Kia Picanto,Essence,"77,000 KM",2021
+0 DT,Mercedes-Benz Classe C,Essence,N.C,2012
+0 DT,Audi Q5,Electrique,"53,000 KM",2021
+0 DT,Dacia Duster,Essence,"170,000 KM",2013
+0 DT,Hyundai i10,Essence,90 KM,N.C
+"26,500 DT",Fiat Grande Punto,Essence,"194,500 KM",2014
+"32,000 DT",Peugeot 308,Essence,"180,000 KM",2015
+"43,000 DT",Renault Clio,Essence,"105,000 KM",2020
+0 DT,Mercedes-Benz Classe C,Essence,N.C,2010
+0 DT,Peugeot Partner,Diesel,"90,000 KM",2012
+"24,800 DT",Renault Clio,Essence,"200,000 KM",2010
+0 DT,Volkswagen Polo,Essence,"186,000 KM",2011
+"42,500 DT",Volkswagen Polo,Essence,"92,500 KM",2021
+"28,000 DT",Volkswagen Passat,Diesel,N.C,2000
+0 DT,Skoda Fabia,Essence,"82,000 KM",2021
+"15,500 DT",Chevrolet Aveo,Essence,"258,000 KM",2005
+"15,500 DT",Renault Symbol,Essence,"390,000 KM",2010
+0 DT,Volkswagen Polo,Diesel,"200,000 KM",2001
+"175,000 DT",Volkswagen Golf 7,Essence,"75,000 KM",2020
+"33,500 DT",BMW Serie 3,Essence,"248,000 KM",2007
+0 DT,Hyundai i20,Essence,"47,000 KM",2022
+"38,000 DT",Hyundai Accent,Essence,"141,000 KM",2016

--- a/clean_data/preset1_cleaned_final.csv
+++ b/clean_data/preset1_cleaned_final.csv
@@ -1,0 +1,715 @@
+Brand,Model,Fuel,Mileage,Year,Price
+KIA,Rio Berline,Essence,163746,2016,35000
+Peugeot,3008,Essence,55000,2022,105000
+Renault,Clio Campus climatisée,Essence,116000,2012,30500
+Chery,Tiggo 3X Luxury,Essence,47000,2022,52000
+Peugeot,3008,Essence,210000,2010,32000
+KIA,Rio Berline,Essence,90500,2020,52000
+Hyundai,Grand i10,Essence,43200,2021,43500
+MG,5,Essence,37000,2022,58000
+Mercedes-Benz,Classe C,Essence,159000,2012,73500
+Mercedes-Benz,GLC Coupé AMG,Hybride,47000,2021,260000
+Haval,H6 Luxury,Essence,100000,2019,77000
+Mercedes-Benz,Classe E,Essence,197000,2010,67000
+Mercedes-Benz,Classe C coupé AMG,Hybride,86000,2019,178000
+Land Rover,Range Rover Evoque R-Dynamic,Diesel,150000,2016,122000
+BMW,Série 4 Gran Coupé,Essence,90000,2019,145000
+Land Rover,Range Rover Velar R-Dynamic,Diesel,55000,2020,258000
+Mercedes-Benz,GLA AMG,Essence,20000,2023,189000
+Hyundai,Kona Hybride N Line,Hybride,19500,2020,97500
+Audi,Q3,Essence,110000,2019,112000
+Porsche,Cayenne,Essence,195000,2012,152000
+MG,HS Trophy,Essence,35000,2021,103000
+Mercedes-Benz,Classe S S 350 phase 2,Essence,165000,2010,122000
+Mercedes-Benz,Classe C AMG,Essence,135000,2019,161300
+Volkswagen,Golf 7 Join,Essence,83000,2018,72000
+Mercedes-Benz,Classe S S350. Toit ouvrant,Essence,147000,2009,98000
+Peugeot,Partner Origin Utilitaire Pack Clim PM,Diesel,73000,2019,56000
+KIA,Sportage GT-Line,Diesel,139000,2018,95000
+Cupra,Formentor Sport,Essence,41000,2022,155000
+Mercedes-Benz,Classe C AMG,Hybride,54000,2018,165000
+Mercedes-Benz,Classe C AMG,Hybride,69000,2020,165000
+Volkswagen,Golf 7 Confortline,Essence,69000,2020,75000
+KIA,Rio 5p,Essence,145000,2019,51000
+Mercedes-Benz,Classe A,Hybride,66000,2021,145000
+Volkswagen,Golf 7,Essence,88000,2018,95000
+BMW,Série 1,Essence,144000,2015,55000
+Volkswagen,Golf 7 Join,Essence,120000,2020,76500
+BMW X,2 Lounge,Essence,0,2024,199000
+Land Rover,Range Rover Evoque R-Dynamic,Diesel,59000,2021,169000
+Volkswagen,Golf 8 R-Line,Hybride,12000,2022,110000
+Mercedes-Benz,GLA AMG,Essence,30000,2018,122000
+Mercedes-Benz,GLC Coupé AMG,Hybride,50000,2021,259000
+Mercedes-Benz,Classe C AMG +,Essence,60000,2021,174000
+Volkswagen,T-roc 1.5,Hybride,9000,2024,155000
+Mercedes-Benz,Classe C AMG,Essence,32000,2022,197000
+Land Rover,Range Rover Evoque R-Dynamic S,Hybride,59000,2021,218000
+Volkswagen,Golf 8,Hybride,40000,2020,115000
+Mercedes-Benz,Classe C AMG +,Hybride,11000,2024,248000
+Suzuki,Jimny,Essence,60000,2021,89500
+Mercedes-Benz,Classe E coupé AMG,Essence,180000,2010,68000
+Volkswagen,T-roc Toit ouvrant,Essence,44000,2020,98000
+Mercedes-Benz,Classe C AMG,Essence,180000,2016,99500
+Mercedes-Benz,GLB AMG,Essence,16000,2023,184000
+Mercedes-Benz,Classe E AMG,Hybride,0,2024,435000
+Mercedes-Benz,Classe C AMG,Essence,175000,2016,109000
+BMW,Série 5 Luxury Line,Essence,155000,2017,124500
+Mercedes-Benz,Classe A A200,Hybride,8000,2024,169000
+KIA,Sportage GT-Line,Hybride,40000,2023,149000
+Land Rover,Range Rover Velar R-Dynamic,Essence,33000,2019,268000
+BMW,Série 7 B7 ALPINA,Essence,115000,2011,158000
+Volkswagen,Golf 8 ÉDITION,Essence,45000,2021,89500
+Mercedes-Benz,Classe E AMG,Hybride,0,2024,450000
+Mercedes-Benz,GLC Coupé AMG,Essence,0,2024,415000
+Mercedes-Benz,CLA AMG,Hybride,42000,2020,169000
+Audi,Q5 Sportback S-Line,Hybride,45000,2022,295000
+Mercedes-Benz,Classe A A 200,Essence,57000,2018,124000
+Mercedes-Benz,CLA AMG,Essence,30000,2023,188000
+Land Rover,Range Rover Sport,Essence,180000,2014,178000
+Porsche,Panamera 4S E-hybride plugin,Hybride,32000,2021,535000
+Mercedes-Benz,GLC Coupé AMG,Essence,106000,2016,225000
+Audi,Q3 Sportback hybrid,Hybride,50000,2021,175000
+Porsche,Cayenne Coupé,Essence,37000,2020,380000
+Jaguar,F-Pace R-Dynamic S,Essence,27000,2021,269000
+BMW X,1 FACELIFT PACK M,Essence,87000,2020,129000
+Mitsubishi,L200 Sportero,Diesel,19000,2022,168000
+Porsche,Cayenne,Hybride,15000,2022,510000
+Audi,A5 Sportback S-Line,Essence,85000,2020,147000
+Mercedes-Benz,ML,Diesel,231000,2010,88000
+Mercedes-Benz,CLA,Diesel,93000,2020,148000
+BMW X,6,Essence,180000,2011,98000
+Mercedes-Benz,GLC Coupé,Hybride,70000,2020,245000
+Mercedes-Benz,Classe G,Diesel,168000,2010,350000
+Peugeot,508,Essence,46000,2020,85000
+Seat,Leon Cupra,Essence,74000,2020,132000
+Volkswagen,Touareg,Diesel,308000,2006,48000
+Mercedes-Benz,Classe S,Hybride,79000,2015,195000
+Peugeot,508,Essence,137000,2019,83000
+Land Rover,Range Rover Sport,Hybride,100000,2019,340000
+BMW,Série 5,Essence,93000,2020,178000
+Mercedes-Benz,GLC Coupé,Essence,0,2024,400000
+BMW,Série 5,Essence,32000,2021,208000
+Mercedes-Benz,Classe G AMG,Essence,30000,2015,630000
+Mercedes-Benz,GLC,Essence,83000,2016,158000
+Mercedes-Benz,CLA,Hybride,69000,2021,174000
+Citroën,DS3,Essence,92000,2017,30500
+Mini,Clubman,Essence,34000,2019,100000
+Mercedes-Benz,Classe S,Hybride,40000,2020,450000
+Nissan,Qashqai,Essence,26000,2022,95000
+Mercedes-Benz,Classe E,Essence,9000,2022,245000
+Mercedes-Benz,GLC Coupé,Essence,6600,2023,360000
+Audi,A5 Sportback,Essence,58000,2021,170000
+Seat,Ateca,Essence,85000,2020,98000
+Porsche,Cayenne E-Hybrid,Hybride,86000,2019,410000
+KIA,Picanto GT-Line,Essence,63000,2022,54500
+Toyota,Prado,Diesel,449000,2003,88000
+BYD,F3,Essence,10000,2022,47000
+Land Rover,Range Rover Sport,Hybride,37000,2020,350000
+Volkswagen,Golf 7,Essence,73000,2017,115000
+Porsche,Macan,Essence,6900,2023,375000
+BMW,Série 3,Essence,80000,2021,174000
+Audi,Q3,Essence,2000,2024,190000
+Porsche,Cayenne Coupé,Essence,59000,2019,370000
+Toyota,Land Cruiser,Diesel,98000,2016,350000
+Mini,5 portes,Essence,75000,2015,58000
+Mercedes-Benz,Classe E coupé,Hybride,86000,2018,340000
+Peugeot,3008,Essence,87000,2019,82000
+Toyota,RAV 4,Essence,280000,2016,56000
+Fiat,500 C,Essence,71000,2017,45500
+Mercedes-Benz,GLC Coupé,Diesel,52000,2020,240000
+Suzuki,Swift,Essence,69000,2020,42000
+Toyota,Corolla,Essence,32000,2022,76000
+Ssangyong,Korando,Essence,80000,2021,92500
+Jeep,Wrangler Sahara,Essence,115000,2018,225000
+Peugeot,2008 Allure,Essence,96000,2015,40000
+BMW,Série 4 Gran Coupé,Essence,121000,2019,100000
+Volkswagen,Tiguan,Essence,123000,2021,95000
+BMW,Série 3 318i,Essence,200000,2015,59000
+Peugeot,307,Essence,110451,2007,25500
+Mercedes-Benz,Classe A AMG,Diesel,96000,2019,118000
+Mini,Countryman All4,Hybride,33000,2020,139500
+MG,ZS,Essence,110000,2021,58000
+Mercedes-Benz,Classe C,Essence,7300,2022,245000
+KIA,Sportage Hybride,Hybride,53000,2020,120000
+BMW,Série 1 Pack M,Essence,110,2020,115000
+Fiat,500 Dolcevita,Hybride,78000,2021,55000
+Fiat,Tipo 5 portes,Essence,68000,2021,49500
+Renault,Clio,Diesel,138000,2020,49500
+Mercedes-Benz,Classe C,Essence,158000,2015,99000
+Suzuki,Celerio,Essence,0,2024,39500
+Volkswagen,Golf 7,Essence,153000,2015,48500
+Renault,Megane,Diesel,148000,2021,59500
+Peugeot,208 Style,Diesel,128000,2020,45500
+Audi,Q5 S-line,Diesel,270000,2014,78000
+Citroën,C1 Importée Tn245,Essence,56000,2021,38500
+Haval,H6 Luxury,Essence,138000,2021,76000
+Peugeot,3008,Diesel,148000,2020,79000
+Volkswagen,Amarok TDI 4*4,Diesel,198000,2012,57000
+Mercedes-Benz,CLA AMG,Diesel,138000,2020,145000
+Mercedes-Benz,CLA Importée Tn245,Diesel,138000,2020,118000
+Mercedes-Benz,CLA,Essence,87000,2021,149000
+Volkswagen,Golf 8 STYLE 1.5 BVA eTSI  importée,Essence,87000,2021,110000
+KIA,Sportage GT-Line,Diesel,119000,2019,98000
+Haval,H6,Essence,16000,2022,99000
+BMW,Série 5 Pack M,Essence,70000,2021,185000
+BMW,Série 4 Gran Coupé,Essence,53000,2020,107000
+Hyundai,Grand i10 Sedan,Essence,150000,2017,30000
+Mercedes-Benz,Classe C AMG +,Essence,146000,2015,135000
+Volkswagen,Golf 8 Active,Essence,69000,2021,95000
+Mercedes-Benz,GLE Coupé,Diesel,54000,2020,420000
+Mazda,CX-5 High Grade,Essence,63000,2019,115000
+MG,ZS,Essence,65000,2019,65000
+Seat,Leon,Essence,61847,2020,70000
+Mercedes-Benz,CLA Urban,Essence,125043,2018,97000
+KIA,Sportage Hybride GT-Line,Hybride,36000,2023,150000
+KIA,Rio 5p SX,Essence,68954,2019,54000
+Volkswagen,Golf 7 Highline,Essence,26043,2016,75000
+Volkswagen,Golf 8 Life,Essence,70001,2020,87000
+Toyota,Land Cruiser,Diesel,142060,2010,175000
+Volkswagen,Golf 7 Confortline,Essence,169452,2019,69000
+BMW,Série 1,Essence,131766,2009,40000
+Mercedes-Benz,Classe E AMG,Essence,55001,2019,165000
+Mercedes-Benz,Classe C AMG +,Essence,0,2024,275000
+Mercedes-Benz,GLA La nouvelle Gla 250e AMG,Hybride,10730,2023,235000
+Mercedes-Benz,Classe E AMG,Essence,10776,2023,390000
+BMW X,3 Luxury Line,Diesel,186000,2006,65000
+Mercedes-Benz,Classe C AMG,Essence,50893,2022,185000
+KIA,Picanto Populaire,Essence,3805,2021,43000
+Lada,4x4 Urban,Essence,24387,2018,36000
+Haval,H6,Essence,12442,2023,126000
+Nissan,Juke Tekna,Essence,163166,2014,51000
+Mitsubishi,Pajero LIMITED EDITION,Diesel,20742,2023,160000
+Mercedes-Benz,CLA AMG Edition 1,Hybride,31235,2021,169900
+Peugeot,308 GT-Line GT-Line,Diesel,96300,2020,64000
+Toyota,Prado,Diesel,199425,2003,129000
+Mini,5 portes,Essence,18000,2021,135000
+BMW,Série 3 coupé,Essence,156000,2010,62000
+Mahindra,KUV 100 K6+,Essence,63000,2021,30000
+Haval,Jolion 1 ere,Essence,30000,2023,93000
+Peugeot,308,Diesel,48000,2023,126000
+Volkswagen,Tiguan R-Line,Essence,54723,2023,198000
+Peugeot,Expert,Diesel,139199,2019,59000
+Volkswagen,Golf 8 R-Line,Hybride,36651,2022,138000
+Mini,Cabrio,Essence,86111,2010,48000
+KIA,Picanto 1 ère main,Essence,0,2024,61000
+Porsche,Cayman S,Essence,39508,2008,275000
+Seat,Ibiza,Essence,99519,2021,54000
+Toyota,Land Cruiser,Diesel,316620,2003,119000
+Mercedes-Benz,GLC Coupé AMG,Hybride,82415,2020,230000
+Mercedes-Benz,Classe C AMG,Essence,249000,2011,65000
+Mercedes-Benz,Classe C,Essence,30570,2021,178000
+Peugeot,3008,Essence,105000,2017,71000
+Mercedes-Benz,CLA AMG,Hybride,1000,2024,225000
+Volkswagen,Golf 8,Essence,85181,2020,88000
+Volkswagen,Golf 7 Join,Essence,86000,2018,79000
+Volkswagen,T-roc,Essence,74107,2019,78000
+Renault,Symbol,Essence,115000,2020,36000
+Mercedes-Benz,CLA AMG,Hybride,18500,2023,185000
+Mercedes-Benz,Classe A AMG,Essence,68000,2018,135000
+BMW,Série 3 Luxury,Essence,112000,2013,65000
+Audi,Q5 S-line,Diesel,176000,2015,110000
+Mercedes-Benz,Classe C AMG,Diesel,145000,2019,145000
+Peugeot,2008 Allure Toit Cielo Blanc Nacré,Essence,125000,2018,50000
+Mercedes-Benz,Classe A AMG,Diesel,141000,2019,119000
+Volkswagen,Golf 8 GTE,Hybride,26000,2021,145000
+Mercedes-Benz,CLA AMG,Hybride,6000,2024,220000
+Mercedes-Benz,Classe A AMG Premium,Essence,131000,2013,78000
+KIA,Picanto,Essence,28000,2021,46500
+Ford,Fusion Titanium,Essence,217000,2016,48000
+Mini,5 portes Très bon état,Essence,160000,2016,49800
+BMW,Série 3,Essence,180000,2012,45000
+Seat,Leon 1.2L,Essence,140000,2018,60000
+Land Rover,Range Rover Sport,Essence,190000,2015,200000
+Peugeot,3008 1.2L,Essence,70000,2020,89000
+Volkswagen,Golf 8,Essence,58000,2022,87000
+KIA,Sportage 1.6L Diesel,Diesel,105000,2018,89000
+Mercedes-Benz,Classe C,Essence,235000,2013,55500
+Audi,Q5 2.0L,Essence,255000,2009,47000
+Volkswagen,Golf 8,Essence,40000,2023,139000
+Mercedes-Benz,Classe C AMG,Essence,164000,2014,89000
+Mercedes-Benz,Classe E 1.6L,Essence,132000,2017,138000
+Seat,Leon Xcellence,Essence,37000,2023,108000
+Jeep,Wrangler 4.0L,Essence,200000,1989,72000
+Renault,Clio 1.0L,Essence,135000,2021,38500
+Audi,A3 Sportback 1.2L,Essence,125000,2019,78500
+Cupra,Formentor 1.5L,Hybride,19000,2022,119000
+Ford,Fusion 1.6,Essence,90000,2017,55500
+Mazda,3,Essence,124000,2017,49500
+Nissan,Juke,Essence,160000,2015,39500
+Volvo,XC60 2.0L,Essence,18000,2022,227000
+Hyundai,Grand i10 1.0L,Essence,57000,2021,39800
+Skoda,Fabia 1.6L,Essence,137000,2018,43000
+BMW,Série 5 520,Essence,182000,2014,75000
+Volkswagen,Golf 8 1.5L,Essence,80000,2021,93000
+BMW X,2 S drive,Essence,74000,2020,132000
+Volkswagen,Golf 7 Importé,Essence,40000,2020,73500
+BMW X,1 1.6L,Essence,126000,2016,85000
+BMW,Série 1 M,Essence,40000,2022,138500
+Citroën,Berlingo Utilitaire 1.6L,Diesel,31000,2023,58500
+Citroën,C3,Essence,92000,2018,38000
+Citroën,C3 Live,Essence,119000,2019,34500
+Citroën,C4,Essence,109000,2012,38000
+Peugeot,3008 Allure,Essence,38000,2019,88000
+Mercedes-Benz,Classe C Avantgarde,Essence,27000,2022,159000
+Peugeot,3008 Allure,Essence,75000,2020,75000
+BMW X,4,Diesel,140000,2018,139000
+Volkswagen,Polo R-Line,Essence,70000,2020,65500
+Volkswagen,Golf 7 BVA,Essence,200000,2020,69000
+BMW,Série 1 Pack Sport M,Essence,165000,2016,75000
+Hyundai,Tucson Top Grade,Essence,40000,2022,147000
+Lada,4x4 Urban,Essence,58000,2020,41000
+Mercedes-Benz,Classe X,Diesel,68000,2020,205000
+Seat,Arona Xperience,Essence,47000,2022,81000
+Toyota,Corolla Dynamic,Essence,85000,2020,69000
+Fiat,500X Pop Star,Essence,60000,2018,65000
+Land Rover,Discovery,Essence,170000,2015,115000
+Haval,Jolion,Essence,40000,2021,88000
+Toyota,C-HR,Essence,130000,2018,73000
+Nissan,Juke Tekna,Essence,6000,2024,92500
+Mercedes-Benz,Classe C AMG,Essence,20000,2023,255100
+Mercedes-Benz,CLA Kit Amg 200,Essence,150000,2020,129000
+Seat,Ibiza Xcellence,Essence,68000,2021,62000
+KIA,Rio 5p SX,Essence,70000,2020,57500
+MG,ZS Luxury,Essence,20000,2022,72000
+Chery,Tiggo 7 Pro,Essence,0,2024,101000
+Audi,Q3 BVA,Essence,3000,2023,165000
+Peugeot,408 GT,Essence,10000,2024,155000
+Jaguar,XF Luxury,Essence,120000,2014,87000
+BMW,Série 6 Face Lift,Essence,190000,2009,85000
+Land Rover,Range Rover Sport HSE Dynamic,Diesel,300000,2016,189000
+KIA,Rio 5p GT-Line,Essence,70000,2021,62000
+KIA,Sportage GT-Line,Hybride,15000,2024,188000
+Mercedes-Benz,GLA 250e Pack AMG,Hybride,26000,2023,225000
+Mahindra,Pick-up SC,Diesel,120000,2021,39000
+Peugeot,3008,Essence,112000,2020,69000
+KIA,Rio 5p GT-Line,Essence,9000,2023,73000
+Mercedes-Benz,Classe C Pack AMG Pack night,Hybride,120000,2019,152000
+Peugeot,3008 GT GT-line,Essence,125000,2020,89000
+MG,HS Luxury,Essence,87000,2020,77900
+Mercedes-Benz,GLA AMG,Essence,90000,2021,173000
+BMW,Série 4 Coupé 420i,Essence,180000,2015,87000
+Chery,Tiggo 7 Pro,Essence,40000,2022,88000
+Suzuki,Jimny,Essence,20000,2023,98000
+Mercedes-Benz,CLA Kit AMG,Essence,124000,2014,83000
+Citroën,C3 Shine,Essence,88000,2018,37500
+Mercedes-Benz,Classe C coupé AMG,Essence,200000,2012,63000
+Renault,Clio 4,Essence,120000,2021,45000
+Mini,3 portes One,Essence,200000,2009,29000
+Hyundai,Tucson High Grade,Essence,19000,2023,129000
+Nissan,Juke Tekna,Essence,53000,2021,87000
+Jeep,Renegade,Essence,88000,2021,88000
+Mercedes-Benz,Classe C AMG,Hybride,120000,2019,152000
+Ford,Mondeo Hybride,Hybride,34000,2020,109000
+Land Rover,Range Rover Evoque,Diesel,145000,2018,120000
+Volkswagen,Passat,Essence,160000,2016,59000
+Haval,H6,Essence,16000,2022,117000
+Haval,H6 Luxury,Essence,55000,2021,85000
+Volkswagen,Golf 8 1.4,Essence,40000,2022,105000
+Jaguar,F-Pace R_Dynamic,Diesel,165000,2017,179000
+Renault,Kadjar,Essence,140000,2018,70000
+Toyota,Corolla,Essence,24000,2022,79000
+Peugeot,308,Essence,128000,2020,47000
+Mercedes-Benz,Classe C coupé AMG,Essence,130000,2018,167000
+Citroën,C3 Shine,Essence,45000,2020,47500
+Ford,Focus Titanium,Essence,200000,2015,40000
+Porsche,Panamera,Essence,82000,2011,178000
+KIA,Seltos,Essence,130000,2021,89000
+Seat,Ibiza FR,Essence,40000,2023,81000
+Alfa Romeo,Giulietta,Essence,37000,2019,77000
+Land Rover,Discovery R-DYNAMIC,Diesel,87000,2020,235000
+Volkswagen,Golf 7 Confortline,Essence,190000,2013,49000
+Renault,Megane 4 Diesel,Diesel,125000,2020,64500
+KIA,Rio 5p GT-Line,Essence,60000,2021,65000
+Fiat,Fiorino,Diesel,120000,2021,35000
+Dacia,Duster Techroad,Essence,35000,2020,75000
+BMW,Série 5 530e Xdrive Pack m,Hybride,50000,2021,278000
+BMW,Série 4 Gran Coupé 418 Luxury,Essence,133000,2016,97000
+Volkswagen,Passat R-Line DSG,Essence,40000,2022,125000
+Toyota,Hilux Double Cabine Gr Sport,Diesel,7000,2024,290000
+Toyota,C-HR,Essence,55000,2022,91000
+Audi,A5 Sportback S-Line,Essence,120000,2019,109000
+Peugeot,2008,Diesel,100000,2021,80000
+KIA,Rio 5p,Essence,85000,2022,59700
+Honda,CR-V,Essence,67000,2018,91000
+Audi,Q5 S-line,Diesel,40000,2021,295000
+KIA,Sportage Hybride,Hybride,114000,2021,107000
+KIA,Sportage GT-Line,Diesel,19000,2021,128000
+Dacia,Duster Techroad,Essence,34000,2020,76000
+Mercedes-Benz,Classe S AMG,Hybride,3000,2022,660000
+BMW X,5 Hybride Xdrive E45,Hybride,19000,2021,455000
+Hyundai,Tucson Hybride Xcellence,Hybride,120000,2022,138000
+BMW,Série 1 I Pack Sport,Essence,200000,2019,75000
+KIA,Sportage GT-Line,Diesel,140000,2017,105000
+Mercedes-Benz,Classe C AMG,Essence,50000,2023,235000
+Jaguar,XE,Diesel,140000,2017,120000
+Peugeot,Rifter,Diesel,95000,2020,72000
+BMW,Série 7 740LI,Essence,98000,2010,110000
+Peugeot,Rifter 5 places,Diesel,95000,2020,72000
+Land Rover,Range Rover Evoque Hybride,Diesel,50000,2019,187000
+Ford,Mondeo Hybride,Hybride,32000,2020,115000
+KIA,Rio 5p GT-Line,Essence,64000,2021,64000
+Mercedes-Benz,GLC AMG,Essence,115000,2017,169000
+Mini,5 portes One,Essence,78000,2016,57000
+Citroën,C3 Shine,Essence,28000,2020,48000
+Audi,A3 Berline,Essence,50000,2019,85000
+KIA,Sportage,Essence,127000,2019,83500
+Mercedes-Benz,GLA AMG,Essence,12000,2023,235000
+Audi,Q3,Essence,95000,2017,95000
+Mercedes-Benz,GLB 200 d,Diesel,111000,2021,210000
+Audi,A4 Face_lift,Essence,143000,2016,58000
+Land Rover,Range Rover Evoque Face_lift,Essence,170000,2016,95000
+BMW,Série 1 Pack M,Essence,40000,2020,135000
+Land Rover,Range Rover Evoque Hybride,Diesel,40000,2019,195000
+Haval,H6 Luxury,Essence,120000,2020,79000
+Iveco,Daily Simple Cabine,Diesel,40000,2022,105000
+Land Rover,Discovery Sport,Diesel,128000,2017,128000
+Haval,H6 Luxury,Essence,40000,2021,90000
+KIA,Sportage Hybride,Hybride,140000,2020,98000
+KIA,Sportage,Essence,125000,2019,85000
+Hyundai,Tucson Hybride,Hybride,80000,2021,137000
+Audi,Q5 QUATTRO 40 TDI,Diesel,170000,2019,165000
+Fiat,Panda City Cross,Essence,52000,2020,43500
+Volkswagen,Golf 6 Match,Diesel,240000,2012,45000
+Ford,Ranger Raptor,Diesel,100000,2022,228000
+BMW,Série 4 Coupé Pack M,Essence,140000,2021,130000
+Mercedes-Benz,Classe B,Essence,100000,2014,48000
+MG,ZS Luxury,Essence,80000,2022,75000
+Land Rover,Range Rover Evoque Hybride,Diesel,60000,2019,210000
+Renault,Kadjar,Essence,70000,2019,68000
+Mazda,3 Sky active,Essence,103000,2017,56000
+Audi,Q8 S_Line,Essence,16000,2021,398000
+Mercedes-Benz,Classe C coupé AMG,Essence,50000,2019,173000
+MG,ZS,Essence,35000,2022,78000
+Suzuki,Baleno,Essence,160000,2017,40000
+KIA,Sportage,Essence,69000,2019,95000
+Ford,Kuga,Essence,100000,2017,69000
+Mercedes-Benz,CLS AMG,Diesel,160000,2011,119000
+Mercedes-Benz,GLA 180 Pack AMG,Essence,40000,2022,185000
+Seat,Arona,Essence,26000,2021,73500
+Toyota,Corolla,Essence,90000,2021,71000
+Haval,H6 Luxury,Essence,115000,2020,79000
+Skoda,Superb Ambassador,Essence,30000,2021,125000
+MG,6,Essence,22000,2021,79000
+Mercedes-Benz,GLC Coupé AMG,Diesel,190000,2017,189000
+Mercedes-Benz,Classe C 180 elegance,Essence,170000,2016,89000
+Mercedes-Benz,GLC Coupé AMG,Hybride,69000,2020,278000
+Mercedes-Benz,Classe E 180,Essence,90000,2018,135000
+Ssangyong,Actyon Sports,Diesel,200000,2017,42000
+DS,3,Essence,138000,2012,35000
+Audi,A3 Berline,Essence,17000,2020,97000
+Nissan,Qashqai,Essence,147000,2011,43000
+BMW,Série 5 Confort Luxury,Essence,200000,2015,90000
+Volkswagen,Passat R-Line,Essence,100000,2019,101000
+Land Rover,Discovery Sport,Diesel,160000,2017,125000
+Citroën,C3 Shine,Essence,90000,2019,44500
+Volkswagen,Amarok,Diesel,370000,2012,49000
+Mercedes-Benz,Classe E Business,Essence,8000,2022,291800
+Mini,3 portes one,Essence,140000,2013,37000
+BMW,Série 1,Essence,126000,2017,68000
+Toyota,Hilux Double Cabine 4*4,Essence,3000,2024,231000
+Peugeot,2008 Allure,Essence,34000,2022,97000
+Mercedes-Benz,Classe A AMG,Essence,20000,2022,158000
+Volkswagen,Passat R-Line,Essence,60000,2020,106000
+Volkswagen,Tiguan,Essence,60000,2018,90000
+Mercedes-Benz,Classe C AMG,Essence,160000,2014,99000
+Chery,Tiggo 8 Pro,Essence,80000,2022,96000
+BYD,F3,Essence,10000,2022,47000
+Citroën,C3 Shine,Essence,58000,2019,44500
+BMW,Série 4 Coupé 420i Pack M,Essence,160000,2015,107000
+Audi,Q3 S-line,Essence,100000,2017,90000
+Volkswagen,Golf 8 United,Essence,26000,2020,109000
+Peugeot,208,Essence,60000,2020,35000
+Audi,A5 Cabriolet S-line,Essence,120000,2010,59000
+Honda,Accord,Essence,11000,2022,135000
+Volkswagen,Golf 7,Essence,40000,2019,74000
+KIA,Sportage,Essence,40000,2020,119000
+BMW,Série 2 Gran Coupé 218i,Essence,21000,2022,135000
+Fiat,Tipo 5 portes,Essence,75000,2018,46000
+Haval,H6,Essence,13000,2022,150600
+Volkswagen,Golf 7 Smartline,Essence,140000,2015,52000
+Haval,H6 Luxury,Essence,90000,2019,78000
+Chevrolet,Cruze,Essence,90000,2018,40000
+Volkswagen,Golf 7,Essence,29000,2019,76000
+Mercedes-Benz,Classe E 200,Essence,330000,2010,51000
+Mercedes-Benz,Classe E e220,Diesel,330000,2011,77000
+Volkswagen,Golf 8 R-Line,Essence,40000,2021,145000
+Mercedes-Benz,Classe C AMG,Essence,16000,2023,240000
+Dodge,RAM Rumble bee,Essence,65000,2019,212000
+Mercedes-Benz,CLA,Essence,163000,2014,81000
+Haval,H2 Luxury,Essence,40000,2019,69000
+Haval,H6 Luxury,Essence,32000,2019,86000
+Mercedes-Benz,CLA AMG,Essence,30000,2021,169000
+Mercedes-Benz,Classe A 180d,Diesel,50000,2019,98000
+Volkswagen,Golf 7,Essence,64000,2019,74000
+Audi,A3 Sportback S-Line,Essence,70000,2019,95000
+Mercedes-Benz,Classe C AMG,Essence,40000,2022,205000
+DS,7 Crossback Grand Chic,Essence,140000,2021,105000
+Mercedes-Benz,Classe C AMG,Essence,50000,2022,264200
+Volkswagen,Golf 7 Join,Essence,70000,2018,84000
+Mercedes-Benz,CLA 220,Diesel,240000,2013,79000
+BMW X,6 Pack M,Diesel,270000,2008,110000
+Audi,A5 Cabriolet S-line,Essence,120000,2010,59000
+Seat,Leon Style,Essence,65000,2020,73000
+Citroën,Berlingo Utilitaire,Diesel,170000,2018,37500
+KIA,Sportage,Essence,23000,2022,143000
+Volkswagen,Golf 7,Essence,180000,2019,64000
+Mercedes-Benz,Classe S Executive,Essence,170000,2008,78000
+Volkswagen,Tiguan Confortline,Essence,33000,2020,128000
+Volkswagen,Golf 7 R-Line,Essence,130000,2018,80000
+Hyundai,Kona,Hybride,30000,2021,79000
+Seat,Leon FR,Essence,70000,2022,122800
+Hyundai,Grand i10,Essence,30000,2022,53000
+Peugeot,2008 GT_LINE,Essence,30000,2021,92000
+Mercedes-Benz,Classe C coupé AMG,Essence,40000,2019,179000
+KIA,Sportage GT-Line,Hybride,120000,2021,119000
+BMW,Série 3 318i,Essence,117000,2017,88000
+Chery,Tiggo 2 Confort,Essence,60000,2020,43500
+Haval,Jolion,Essence,40000,2022,87000
+Mercedes-Benz,Classe C AMG,Essence,40000,2022,208000
+Hyundai,Grand i10,Essence,54000,2021,53000
+Seat,Ibiza FR,Essence,100000,2020,68000
+Mercedes-Benz,CLA AMG,Essence,20000,2020,169000
+Seat,Ibiza FR,Essence,50000,2020,67000
+Volkswagen,T-roc,Essence,87000,2020,85000
+Mercedes-Benz,GLA AMG,Essence,74000,2016,113000
+Mercedes-Benz,Classe C AMG,Essence,170000,2014,115000
+Audi,Q3 Sportback,Essence,10000,2021,188000
+Audi,Q5,Diesel,100000,2018,215000
+Volkswagen,Golf 8 R-Line,Essence,70000,2021,125000
+Jaguar,F-Pace R-DYNAMIC,Diesel,165000,2017,185000
+Peugeot,3008 GT-line,Essence,260000,2017,77000
+Land Rover,Range Rover Velar R-Dynamic,Diesel,100000,2019,350000
+Porsche,Panamera PLATINUM édition,Essence,100000,2014,255000
+Land Rover,Range Rover Velar R-Dynamic,Essence,90000,2020,295000
+Dongfeng,Forthing T5 EVO,Essence,4000,2023,182900
+Chery,Tiggo 3,Essence,75000,2018,47000
+Audi,Q3,Essence,77000,2017,85000
+Renault,Kadjar Intens,Essence,150000,2018,66000
+Volkswagen,Golf 8 R-Line,Essence,40000,2021,155000
+Mercedes-Benz,Classe C AMG,Hybride,35000,2020,205000
+Volkswagen,Golf 7 Join,Essence,120000,2019,80000
+BMW,Série 4 Gran Coupé Luxury,Essence,100000,2018,99000
+Hyundai,Tucson,Essence,24000,2023,161000
+Hyundai,Tucson,Essence,120000,2020,87000
+BMW,Série 1 Pack sport,Essence,70000,2020,92000
+Fiat,Panda City Cross,Essence,20000,2022,45000
+BMW,Série 4 Gran Coupé 418 PACK M,Essence,110000,2017,125000
+Mercedes-Benz,Classe E AMG,Essence,135000,2011,77000
+Mercedes-Benz,Classe C AMG,Essence,80000,2022,215000
+Dongfeng,SX3,Essence,30000,2021,65000
+Volkswagen,Golf 8 United,Essence,16000,2021,128000
+Mercedes-Benz,Classe A AMG,Essence,15000,2022,172000
+Mercedes-Benz,Classe C AMG,Diesel,80000,2019,148000
+MG,GS Luxe,Essence,115000,2017,62000
+Mitsubishi,ASX 4WD,Essence,55000,2021,122800
+Land Rover,Discovery,Diesel,130000,2017,126000
+Audi,A5 Sportback,Essence,70000,2021,185000
+BMW,Série 7 Individuel,Essence,300000,2008,45000
+Land Rover,Range Rover Sport,Diesel,160000,2014,245000
+BMW,Série 4 Coupé,Essence,78000,2017,110000
+MG,GS Luxe Plus,Essence,100000,2017,61000
+Peugeot,RCZ,Essence,171000,2011,40000
+Land Rover,Discovery Sport,Diesel,94000,2016,118000
+Volkswagen,Amarok AWD,Diesel,180000,2016,87000
+BMW,Série 7 740I FACE-LIFT,Essence,220000,2008,55000
+Ford,Ecosport Titanium,Essence,67000,2022,69000
+Toyota,Corolla Cross Hybride High,Hybride,36000,2022,120000
+MG,ZS Confort Plus,Essence,141000,2019,58000
+KIA,Sportage,Essence,150000,2019,85000
+BMW,Série 3 coupé Kit M///,Essence,152000,2012,74000
+Mercedes-Benz,Classe C AMG,Essence,200000,2011,71000
+Audi,A5 Coupé,Essence,109000,2014,75000
+KIA,Rio 5p SX,Essence,35000,2020,58500
+BMW,Série 1 Business Line,Essence,251000,2012,36500
+Volkswagen,Golf 7 Sound,Essence,125000,2018,78000
+Mercedes-Benz,CLA AMG,Hybride,25000,2021,170000
+Mercedes-Benz,Classe A AMG,Hybride,35000,2020,135000
+Peugeot,308,Essence,102000,2020,50000
+Ford,Ecosport Titanium,Essence,44000,2022,67000
+Fiat,500 Cult Club,Essence,3000,2023,62000
+Mercedes-Benz,Classe A AMG,Essence,60000,2021,115000
+Volkswagen,Tiguan R-Line,Essence,160000,2019,110000
+Volkswagen,Scirocco,Essence,200000,2010,40000
+Audi,A5 Sportback,Essence,80000,2019,115000
+Hyundai,Tucson,Diesel,81000,2018,100000
+Land Rover,Discovery,Essence,110000,2016,125000
+Mercedes-Benz,Classe A,Essence,90000,2021,110000
+Hyundai,Tucson Hybride Top Grade,Diesel,16000,2023,178000
+Peugeot,508,Essence,145000,2018,51000
+Mercedes-Benz,Classe C coupé AMG,Essence,120000,2019,145000
+Land Rover,Range Rover Sport,Diesel,90000,2017,230000
+Porsche,Cayenne,Essence,158000,2015,220000
+BMW,Série 3,Essence,210000,2015,67000
+Mercedes-Benz,Classe A,Essence,50000,2020,108000
+Mercedes-Benz,Classe C,Essence,180000,2013,66000
+Renault,Kadjar,Essence,98000,2021,83000
+Land Rover,Range Rover Sport,Diesel,208000,2007,85000
+Audi,Q3,Hybride,40000,2023,200000
+KIA,Sorento,Diesel,120000,2016,95000
+KIA,Sportage,Diesel,140000,2018,118000
+KIA,Rio 5p SX PLUS,Essence,99000,2020,53000
+Wallyscar,719,Essence,86573,2023,47100
+Renault,Megane Sedan,Essence,46000,2019,61000
+Ford,Ecosport,Essence,19000,2022,78000
+Mercedes-Benz,ML,Diesel,250000,2007,58000
+Ford,Focus Trend Sport,Essence,180000,2014,36000
+Toyota,Prado Adventure,Diesel,330000,1999,65000
+Peugeot,207 Access Plus,Diesel,290000,2011,27500
+Mercedes-Benz,CLA,Diesel,60000,2021,145000
+Hyundai,ix35 Toit Panoramique,Diesel,160000,2016,63500
+Volkswagen,Polo Sedan Trendline,Essence,170000,2020,41300
+Mercedes-Benz,Classe A AMG,Essence,180000,2014,68500
+Mercedes-Benz,GLC Coupé AMG,Essence,0,2024,420000
+Mercedes-Benz,Classe C,Essence,200000,2014,105000
+Ssangyong,Tivoli Confort Plus,Essence,4700,2018,65000
+Mini,3 portes John Cooper Works,Essence,100000,2017,63000
+Toyota,Hilux Double Cabine D4D,Diesel,140000,2020,168000
+Land Rover,Range Rover Evoque HSE,Hybride,60000,2022,255000
+Mercedes-Benz,Classe A Berline AMG,Essence,100000,2020,132000
+Land Rover,Range Rover Sport Autobiography,Hybride,60000,2021,385000
+Mercedes-Benz,CLA AMG,Essence,0,2024,220000
+Porsche,Cayenne Coupé GTS,Hybride,70000,2020,480000
+Mercedes-Benz,GLE Coupé,Hybride,30000,2022,450000
+Mercedes-Benz,Classe E AMG,Hybride,70000,2020,260000
+Mercedes-Benz,GLC Coupé AMG,Hybride,80000,2021,270000
+BMW,Série 4 Gran Coupé KIT-M-individual,Essence,120000,2016,145000
+Mercedes-Benz,CLA,Diesel,130000,2017,115000
+Audi,A3 Sportback 1.5,Hybride,900,2023,145000
+Tesla,Model 3 Modèle 3 Highland 2024,Electrique,15000,2023,190000
+Mercedes-Benz,GLC AMG,Hybride,130000,2018,197000
+Mercedes-Benz,Classe E,Diesel,158000,2020,168000
+Nissan,Qashqai,Diesel,147000,2016,56000
+Hyundai,Tucson,Essence,37000,2022,145000
+Audi,Q2 Design,Essence,77000,2019,95000
+KIA,Rio 5p,Essence,51000,2021,62000
+Toyota,C-HR,Essence,71000,2021,85000
+KIA,Sportage Black Edition,Essence,117000,2018,78000
+Mahindra,KUV 100 K6+,Essence,90000,2021,26000
+Toyota,C-HR,Essence,165000,2020,75000
+Ford,Fiesta Trend,Essence,161000,2013,28000
+BMW,Série 4 Coupé M,Essence,85000,2019,150000
+Renault,Megane Sedan,Essence,70000,2021,60000
+Mazda,CX-9 High grade,Essence,155000,2019,104000
+Ford,Fiesta Titanium,Essence,223000,2013,29500
+Peugeot,Partner,Diesel,320000,2009,26000
+Suzuki,Celerio,Essence,45000,2022,37900
+Mercedes-Benz,CLA AMG,Essence,100000,2020,144900
+MG,HS Trophy,Essence,111000,2022,90000
+Seat,Ibiza,Essence,83000,2019,41500
+Ssangyong,Tivoli,Essence,235000,2018,48000
+Mahindra,KUV 100 K6+,Essence,59000,2022,32500
+Hyundai,H-1,Essence,999999,2006,18000
+Nissan,Micra,Essence,130000,2017,29500
+BMW,Serie 1,Essence,240000,2007,28600
+Fiat,Doblo,Diesel,160000,2020,25800
+Mercedes-Benz,Classe C,Essence,207600,2014,78000
+Kia,Cerato,Essence,14400,2015,39500
+Kia,Rio,Essence,90000,2021,55500
+Volkswagen,Polo,Essence,140000,2021,44500
+Renault,Clio,Essence,116000,2012,30500
+Citroen,C5,Essence,250,2024,950
+Peugeot,207,Essence,229999,2012,17500
+Citroen,Nemo,Diesel,420000,2014,20000
+Peugeot,306,Essence,202000,2000,13500
+Citroen,C3,Essence,97000,2018,34000
+SsangYong,Actyon,Diesel,424000,2015,29000
+Opel,Corsa,Essence,312,,9000
+Volkswagen,Golf 5,Essence,170000,2007,1111
+Peugeot,3008,Essence,100000,2019,66500
+Peugeot,Partner,Diesel,70000,2020,78000
+Skoda,Fabia,Essence,130000,2021,41500
+BMW,Serie 4,Essence,150000,2019,105000
+BMW X,4,Essence,62000,2016,152000
+Fiat,Tipo,Essence,113000,2020,53000
+Renault,Megane,Essence,150000,2020,48500
+Ford,Focus,Essence,60000,2020,79000
+Nissan,Juke,Essence,27000,2023,82000
+Peugeot,2008,Essence,117000,2018,44000
+Nissan,Micra,Essence,74300,2020,33800
+Mercedes-Benz,Classe E,Essence,197000,2010,67000
+Audi,A6,Essence,166920,2016,55000
+Hyundai,i10,Essence,65000,2023,41000
+Kia,Sportage,Essence,45000,,96000
+Jeep,Compass,Essence,64000,2020,1111
+BMW,Serie 4,Essence,150000,2019,1111
+Land Rover,Range Rover Sport,Hybride,42000,2020,1111
+Fiat,Panda,Essence,130000,2022,38500
+Ford,Focus,Essence,120000,2016,42000
+Kia,Sportage,Essence,160000,2017,75000
+Fiat,500C,Essence,71000,2017,45500
+Citroen,DS5,Essence,110000,2017,61500
+Citroen,C3,Essence,98270,2018,42000
+Kia,Sportage,N.C,54000,2020,117000
+Volkswagen,Passat,Essence,140000,2016,58000
+Peugeot,2008,Essence,90000,2019,54000
+Chery,QQ,Essence,104000,2019,22800
+Peugeot,208,Essence,78000,2021,45500
+Audi,A3,Essence,98000,2020,78000
+Opel,Corsa,Essence,266000,2000,13500
+SEAT,Leon,Essence,61847,2019,70000
+Citroen,C3,Essence,58000,2021,35500
+Kia,Picanto,Essence,28000,2021,46500
+MG,ZS,Essence,13,2024,90000
+Nissan,Navara,Diesel,315000,2012,47000
+Peugeot,508,Essence,268000,2012,30000
+Renault,Clio,Essence,110000,2016,40500
+Renault,Megane,Diesel,350000,2007,19500
+Kia,Rio,Essence,170000,2021,48500
+Renault,Clio,Essence,80000,2021,42500
+Renault,Clio,Essence,300000,1993,8500
+Renault,Clio,Essence,,2023,400
+Citroen,C-Elysee,Essence,70000,2020,36500
+Volkswagen,Polo,Essence,,2022,52000
+Mazda,BT-50,Essence,190000,2015,120000
+Nissan,Micra,Essence,160000,2013,26000
+Kia,Rio,Essence,48000,2024,61500
+Opel,Corsa,Essence,350000,2000,12800
+Mazda,CX-9,Essence,286000,2010,46000
+Renault,Clio,Essence,91300,2020,41000
+SsangYong,Tivoli,Essence,74000,2020,61000
+Mercedes-Benz,Classe CLA,Essence,170000,2014,77500
+BMW X,5,Diesel,280000,2008,67500
+Toyota,Aygo,Essence,90000,2021,40900
+Peugeot,205,Essence,111000,1993,9000
+Peugeot,207,Diesel,290000,2011,27500
+Renault,R4,Essence,57000,1980,1000
+Renault,Clio,Essence,123000,2005,10000
+Hyundai,Santa Fe,Diesel,48000,2020,190000
+Peugeot,206,Essence,,2001,19000
+Fiat,Fiorino,Diesel,112000,2019,32000
+Mercedes-Benz,Classe C,Essence,9000,2021,173000
+Chevrolet,Spark,Essence,121000,2015,27000
+Peugeot,308,Essence,168000,2015,35000
+SEAT,Ibiza,Essence,205000,2020,37000
+Hyundai,i20,Essence,72000,2022,51500
+Citroen,C3,Essence,195540,2007,19700
+Toyota,C-HR,Essence,711000,2021,85000
+Volkswagen,Polo,Essence,47000,2006,25000
+Hyundai,i10,Essence,88000,2018,33000
+Citroen,Berlingo,Diesel,76470,2015,38500
+Mercedes-Benz,Classe A,Essence,10000,2002,220000
+Volkswagen,Caddy,Diesel,124000,2020,64000
+Peugeot,Partner,Diesel,282000,2016,33000
+BMW X,5,Essence,154000,2009,65000
+Peugeot,208,Essence,113000,2017,30000
+Volkswagen,Passat,Diesel,300000,2013,56000
+Toyota,C-HR,Essence,165000,2020,75000
+Renault,Megane,Essence,60000,2021,60000
+Mercedes-Benz,Classe A,Essence,100000,2002,25000
+Peugeot,206,Diesel,,2003,8000
+Peugeot,301,Essence,106000,2014,22000
+Peugeot,301,Essence,170000,2015,24500
+Suzuki,Swift,Essence,49500,2019,42500
+Kia,Picanto,Essence,74000,2020,42300
+Kia,Picanto,Essence,77000,2021,40000
+Fiat,Grande Punto,Essence,194500,2014,26500
+Peugeot,308,Essence,180000,2015,32000
+Renault,Clio,Essence,105000,2020,43000
+Renault,Clio,Essence,200000,2010,24800
+Volkswagen,Polo,Essence,92500,2021,42500
+Volkswagen,Passat,Diesel,,2000,28000
+Chevrolet,Aveo,Essence,258000,2005,15500
+Renault,Symbol,Essence,390000,2010,15500
+Volkswagen,Golf 7,Essence,75000,2020,175000
+BMW,Serie 3,Essence,248000,2007,33500
+Hyundai,Accent,Essence,141000,2016,38000

--- a/clean_data/preset1_datastructure_fixed.csv
+++ b/clean_data/preset1_datastructure_fixed.csv
@@ -1,0 +1,715 @@
+Price,Title,Fuel,Mileage,Year
+35000,KIA Rio Berline,Essence,163746.0,2016
+105000,Peugeot 3008,Essence,55000.0,2022
+30500,Renault Clio Campus climatisée,Essence,116000.0,2012
+52000,Chery Tiggo 3X Luxury,Essence,47000.0,2022
+32000,Peugeot 3008,Essence,210000.0,2010
+52000,KIA Rio Berline,Essence,90500.0,2020
+43500,Hyundai Grand i10,Essence,43200.0,2021
+58000,MG 5,Essence,37000.0,2022
+73500,Mercedes-Benz Classe C,Essence,159000.0,2012
+260000,Mercedes-Benz GLC Coupé AMG,Hybride,47000.0,2021
+77000,Haval H6 Luxury,Essence,100000.0,2019
+67000,Mercedes-Benz Classe E,Essence,197000.0,2010
+178000,Mercedes-Benz Classe C coupé AMG,Hybride,86000.0,2019
+122000,Land Rover Range Rover Evoque R-Dynamic,Diesel,150000.0,2016
+145000,BMW Série 4 Gran Coupé,Essence,90000.0,2019
+258000,Land Rover Range Rover Velar R-Dynamic,Diesel,55000.0,2020
+189000,Mercedes-Benz GLA AMG,Essence,20000.0,2023
+97500,Hyundai Kona Hybride N Line,Hybride,19500.0,2020
+112000,Audi Q3,Essence,110000.0,2019
+152000,Porsche Cayenne,Essence,195000.0,2012
+103000,MG HS Trophy,Essence,35000.0,2021
+122000,Mercedes-Benz Classe S S 350 phase 2,Essence,165000.0,2010
+161300,Mercedes-Benz Classe C AMG,Essence,135000.0,2019
+72000,Volkswagen Golf 7 Join,Essence,83000.0,2018
+98000,Mercedes-Benz Classe S S350. Toit ouvrant,Essence,147000.0,2009
+56000,Peugeot Partner Origin Utilitaire Pack Clim PM,Diesel,73000.0,2019
+95000,KIA Sportage GT-Line,Diesel,139000.0,2018
+155000,Cupra Formentor Sport,Essence,41000.0,2022
+165000,Mercedes-Benz Classe C AMG,Hybride,54000.0,2018
+165000,Mercedes-Benz Classe C AMG,Hybride,69000.0,2020
+75000,Volkswagen Golf 7 Confortline,Essence,69000.0,2020
+51000,KIA Rio 5p,Essence,145000.0,2019
+145000,Mercedes-Benz Classe A,Hybride,66000.0,2021
+95000,Volkswagen Golf 7,Essence,88000.0,2018
+55000,BMW Série 1,Essence,144000.0,2015
+76500,Volkswagen Golf 7 Join,Essence,120000.0,2020
+199000,BMW X2 Lounge,Essence,0.0,2024
+169000,Land Rover Range Rover Evoque R-Dynamic,Diesel,59000.0,2021
+110000,Volkswagen Golf 8 R-Line,Hybride,12000.0,2022
+122000,Mercedes-Benz GLA AMG,Essence,30000.0,2018
+259000,Mercedes-Benz GLC Coupé AMG,Hybride,50000.0,2021
+174000,Mercedes-Benz Classe C AMG +,Essence,60000.0,2021
+155000,Volkswagen T-roc 1.5,Hybride,9000.0,2024
+197000,Mercedes-Benz Classe C AMG,Essence,32000.0,2022
+218000,Land Rover Range Rover Evoque R-Dynamic S,Hybride,59000.0,2021
+115000,Volkswagen Golf 8,Hybride,40000.0,2020
+248000,Mercedes-Benz Classe C AMG +,Hybride,11000.0,2024
+89500,Suzuki Jimny,Essence,60000.0,2021
+68000,Mercedes-Benz Classe E coupé AMG,Essence,180000.0,2010
+98000,Volkswagen T-roc Toit ouvrant,Essence,44000.0,2020
+99500,Mercedes-Benz Classe C AMG,Essence,180000.0,2016
+184000,Mercedes-Benz GLB AMG,Essence,16000.0,2023
+435000,Mercedes-Benz Classe E AMG,Hybride,0.0,2024
+109000,Mercedes-Benz Classe C AMG,Essence,175000.0,2016
+124500,BMW Série 5 Luxury Line,Essence,155000.0,2017
+169000,Mercedes-Benz Classe A A200,Hybride,8000.0,2024
+149000,KIA Sportage GT-Line,Hybride,40000.0,2023
+268000,Land Rover Range Rover Velar R-Dynamic,Essence,33000.0,2019
+158000,BMW Série 7 B7 ALPINA,Essence,115000.0,2011
+89500,Volkswagen Golf 8 ÉDITION,Essence,45000.0,2021
+450000,Mercedes-Benz Classe E AMG,Hybride,0.0,2024
+415000,Mercedes-Benz GLC Coupé AMG,Essence,0.0,2024
+169000,Mercedes-Benz CLA AMG,Hybride,42000.0,2020
+295000,Audi Q5 Sportback S-Line,Hybride,45000.0,2022
+124000,Mercedes-Benz Classe A A 200,Essence,57000.0,2018
+188000,Mercedes-Benz CLA AMG,Essence,30000.0,2023
+178000,Land Rover Range Rover Sport,Essence,180000.0,2014
+535000,Porsche Panamera 4S E-hybride plugin,Hybride,32000.0,2021
+225000,Mercedes-Benz GLC Coupé AMG,Essence,106000.0,2016
+175000,Audi Q3 Sportback hybrid,Hybride,50000.0,2021
+380000,Porsche Cayenne Coupé,Essence,37000.0,2020
+269000,Jaguar F-Pace R-Dynamic S,Essence,27000.0,2021
+129000,BMW X1 FACELIFT PACK M,Essence,87000.0,2020
+168000,Mitsubishi L200 Sportero,Diesel,19000.0,2022
+510000,Porsche Cayenne,Hybride,15000.0,2022
+147000,Audi A5 Sportback S-Line,Essence,85000.0,2020
+88000,Mercedes-Benz ML,Diesel,231000.0,2010
+148000,Mercedes-Benz CLA,Diesel,93000.0,2020
+98000,BMW X6,Essence,180000.0,2011
+245000,Mercedes-Benz GLC Coupé,Hybride,70000.0,2020
+350000,Mercedes-Benz Classe G,Diesel,168000.0,2010
+85000,Peugeot 508,Essence,46000.0,2020
+132000,Seat Leon Cupra,Essence,74000.0,2020
+48000,Volkswagen Touareg,Diesel,308000.0,2006
+195000,Mercedes-Benz Classe S,Hybride,79000.0,2015
+83000,Peugeot 508,Essence,137000.0,2019
+340000,Land Rover Range Rover Sport,Hybride,100000.0,2019
+178000,BMW Série 5,Essence,93000.0,2020
+400000,Mercedes-Benz GLC Coupé,Essence,0.0,2024
+208000,BMW Série 5,Essence,32000.0,2021
+630000,Mercedes-Benz Classe G AMG,Essence,30000.0,2015
+158000,Mercedes-Benz GLC,Essence,83000.0,2016
+174000,Mercedes-Benz CLA,Hybride,69000.0,2021
+30500,Citroën DS3,Essence,92000.0,2017
+100000,Mini Clubman,Essence,34000.0,2019
+450000,Mercedes-Benz Classe S,Hybride,40000.0,2020
+95000,Nissan Qashqai,Essence,26000.0,2022
+245000,Mercedes-Benz Classe E,Essence,9000.0,2022
+360000,Mercedes-Benz GLC Coupé,Essence,6600.0,2023
+170000,Audi A5 Sportback,Essence,58000.0,2021
+98000,Seat Ateca,Essence,85000.0,2020
+410000,Porsche Cayenne E-Hybrid,Hybride,86000.0,2019
+54500,KIA Picanto GT-Line,Essence,63000.0,2022
+88000,Toyota Prado,Diesel,449000.0,2003
+47000,BYD F3,Essence,10000.0,2022
+350000,Land Rover Range Rover Sport,Hybride,37000.0,2020
+115000,Volkswagen Golf 7,Essence,73000.0,2017
+375000,Porsche Macan,Essence,6900.0,2023
+174000,BMW Série 3,Essence,80000.0,2021
+190000,Audi Q3,Essence,2000.0,2024
+370000,Porsche Cayenne Coupé,Essence,59000.0,2019
+350000,Toyota Land Cruiser,Diesel,98000.0,2016
+58000,Mini 5 portes,Essence,75000.0,2015
+340000,Mercedes-Benz Classe E coupé,Hybride,86000.0,2018
+82000,Peugeot 3008,Essence,87000.0,2019
+56000,Toyota RAV 4,Essence,280000.0,2016
+45500,Fiat 500 C,Essence,71000.0,2017
+240000,Mercedes-Benz GLC Coupé,Diesel,52000.0,2020
+42000,Suzuki Swift,Essence,69000.0,2020
+76000,Toyota Corolla,Essence,32000.0,2022
+92500,Ssangyong Korando,Essence,80000.0,2021
+225000,Jeep Wrangler Sahara,Essence,115000.0,2018
+40000,Peugeot 2008 Allure,Essence,96000.0,2015
+100000,BMW Série 4 Gran Coupé,Essence,121000.0,2019
+95000,Volkswagen Tiguan,Essence,123000.0,2021
+59000,BMW Série 3 318i,Essence,200000.0,2015
+25500,Peugeot 307,Essence,110451.0,2007
+118000,Mercedes-Benz Classe A AMG,Diesel,96000.0,2019
+139500,Mini Countryman All4,Hybride,33000.0,2020
+58000,MG ZS,Essence,110000.0,2021
+245000,Mercedes-Benz Classe C,Essence,7300.0,2022
+120000,KIA Sportage Hybride,Hybride,53000.0,2020
+115000,BMW Série 1 Pack M,Essence,110.0,2020
+55000,Fiat 500 Dolcevita,Hybride,78000.0,2021
+49500,Fiat Tipo 5 portes,Essence,68000.0,2021
+49500,Renault Clio,Diesel,138000.0,2020
+99000,Mercedes-Benz Classe C,Essence,158000.0,2015
+39500,Suzuki Celerio,Essence,0.0,2024
+48500,Volkswagen Golf 7,Essence,153000.0,2015
+59500,Renault Megane,Diesel,148000.0,2021
+45500,Peugeot 208 Style,Diesel,128000.0,2020
+78000,Audi Q5 S-line,Diesel,270000.0,2014
+38500,Citroën C1 Importée Tn245,Essence,56000.0,2021
+76000,Haval H6 Luxury,Essence,138000.0,2021
+79000,Peugeot 3008,Diesel,148000.0,2020
+57000,Volkswagen Amarok TDI 4*4,Diesel,198000.0,2012
+145000,Mercedes-Benz CLA AMG,Diesel,138000.0,2020
+118000,Mercedes-Benz CLA Importée Tn245,Diesel,138000.0,2020
+149000,Mercedes-Benz CLA,Essence,87000.0,2021
+110000,Volkswagen Golf 8 STYLE 1.5 BVA eTSI  importée,Essence,87000.0,2021
+98000,KIA Sportage GT-Line,Diesel,119000.0,2019
+99000,Haval H6,Essence,16000.0,2022
+185000,BMW Série 5 Pack M,Essence,70000.0,2021
+107000,BMW Série 4 Gran Coupé,Essence,53000.0,2020
+30000,Hyundai Grand i10 Sedan,Essence,150000.0,2017
+135000,Mercedes-Benz Classe C AMG +,Essence,146000.0,2015
+95000,Volkswagen Golf 8 Active,Essence,69000.0,2021
+420000,Mercedes-Benz GLE Coupé,Diesel,54000.0,2020
+115000,Mazda CX-5 High Grade,Essence,63000.0,2019
+65000,MG ZS,Essence,65000.0,2019
+70000,Seat Leon,Essence,61847.0,2020
+97000,Mercedes-Benz CLA Urban,Essence,125043.0,2018
+150000,KIA Sportage Hybride GT-Line,Hybride,36000.0,2023
+54000,KIA Rio 5p SX,Essence,68954.0,2019
+75000,Volkswagen Golf 7 Highline,Essence,26043.0,2016
+87000,Volkswagen Golf 8 Life,Essence,70001.0,2020
+175000,Toyota Land Cruiser,Diesel,142060.0,2010
+69000,Volkswagen Golf 7 Confortline,Essence,169452.0,2019
+40000,BMW Série 1,Essence,131766.0,2009
+165000,Mercedes-Benz Classe E AMG,Essence,55001.0,2019
+275000,Mercedes-Benz Classe C AMG +,Essence,0.0,2024
+235000,Mercedes-Benz GLA La nouvelle Gla 250e AMG,Hybride,10730.0,2023
+390000,Mercedes-Benz Classe E AMG,Essence,10776.0,2023
+65000,BMW X3 Luxury Line,Diesel,186000.0,2006
+185000,Mercedes-Benz Classe C AMG,Essence,50893.0,2022
+43000,KIA Picanto Populaire,Essence,3805.0,2021
+36000,Lada 4x4 Urban,Essence,24387.0,2018
+126000,Haval H6,Essence,12442.0,2023
+51000,Nissan Juke Tekna,Essence,163166.0,2014
+160000,Mitsubishi Pajero LIMITED EDITION,Diesel,20742.0,2023
+169900,Mercedes-Benz CLA AMG Edition 1,Hybride,31235.0,2021
+64000,Peugeot 308 GT-Line GT-Line,Diesel,96300.0,2020
+129000,Toyota Prado,Diesel,199425.0,2003
+135000,Mini 5 portes,Essence,18000.0,2021
+62000,BMW Série 3 coupé,Essence,156000.0,2010
+30000,Mahindra KUV 100 K6+,Essence,63000.0,2021
+93000,Haval Jolion 1 ere,Essence,30000.0,2023
+126000,Peugeot 308,Diesel,48000.0,2023
+198000,Volkswagen Tiguan R-Line,Essence,54723.0,2023
+59000,Peugeot Expert,Diesel,139199.0,2019
+138000,Volkswagen Golf 8 R-Line,Hybride,36651.0,2022
+48000,Mini Cabrio,Essence,86111.0,2010
+61000,KIA Picanto 1 ère main,Essence,0.0,2024
+275000,Porsche Cayman S,Essence,39508.0,2008
+54000,Seat Ibiza,Essence,99519.0,2021
+119000,Toyota Land Cruiser,Diesel,316620.0,2003
+230000,Mercedes-Benz GLC Coupé AMG,Hybride,82415.0,2020
+65000,Mercedes-Benz Classe C AMG,Essence,249000.0,2011
+178000,Mercedes-Benz Classe C,Essence,30570.0,2021
+71000,Peugeot 3008,Essence,105000.0,2017
+225000,Mercedes-Benz CLA AMG,Hybride,1000.0,2024
+88000,Volkswagen Golf 8,Essence,85181.0,2020
+79000,Volkswagen Golf 7 Join,Essence,86000.0,2018
+78000,Volkswagen T-roc,Essence,74107.0,2019
+36000,Renault Symbol,Essence,115000.0,2020
+185000,Mercedes-Benz CLA AMG,Hybride,18500.0,2023
+135000,Mercedes-Benz Classe A AMG,Essence,68000.0,2018
+65000,BMW Série 3 Luxury,Essence,112000.0,2013
+110000,Audi Q5 S-line,Diesel,176000.0,2015
+145000,Mercedes-Benz Classe C AMG,Diesel,145000.0,2019
+50000,Peugeot 2008 Allure Toit Cielo Blanc Nacré,Essence,125000.0,2018
+119000,Mercedes-Benz Classe A AMG,Diesel,141000.0,2019
+145000,Volkswagen Golf 8 GTE,Hybride,26000.0,2021
+220000,Mercedes-Benz CLA AMG,Hybride,6000.0,2024
+78000,Mercedes-Benz Classe A AMG Premium,Essence,131000.0,2013
+46500,KIA Picanto,Essence,28000.0,2021
+48000,Ford Fusion Titanium,Essence,217000.0,2016
+49800,Mini 5 portes Très bon état,Essence,160000.0,2016
+45000,BMW Série 3,Essence,180000.0,2012
+60000,Seat Leon 1.2L,Essence,140000.0,2018
+200000,Land Rover Range Rover Sport,Essence,190000.0,2015
+89000,Peugeot 3008 1.2L,Essence,70000.0,2020
+87000,Volkswagen Golf 8,Essence,58000.0,2022
+89000,KIA Sportage 1.6L Diesel,Diesel,105000.0,2018
+55500,Mercedes-Benz Classe C,Essence,235000.0,2013
+47000,Audi Q5 2.0L,Essence,255000.0,2009
+139000,Volkswagen Golf 8,Essence,40000.0,2023
+89000,Mercedes-Benz Classe C AMG,Essence,164000.0,2014
+138000,Mercedes-Benz Classe E 1.6L,Essence,132000.0,2017
+108000,Seat Leon Xcellence,Essence,37000.0,2023
+72000,Jeep Wrangler 4.0L,Essence,200000.0,1989
+38500,Renault Clio 1.0L,Essence,135000.0,2021
+78500,Audi A3 Sportback 1.2L,Essence,125000.0,2019
+119000,Cupra Formentor 1.5L,Hybride,19000.0,2022
+55500,Ford Fusion 1.6,Essence,90000.0,2017
+49500,Mazda 3,Essence,124000.0,2017
+39500,Nissan Juke,Essence,160000.0,2015
+227000,Volvo XC60 2.0L,Essence,18000.0,2022
+39800,Hyundai Grand i10 1.0L,Essence,57000.0,2021
+43000,Skoda Fabia 1.6L,Essence,137000.0,2018
+75000,BMW Série 5 520,Essence,182000.0,2014
+93000,Volkswagen Golf 8 1.5L,Essence,80000.0,2021
+132000,BMW X2 S drive,Essence,74000.0,2020
+73500,Volkswagen Golf 7 Importé,Essence,40000.0,2020
+85000,BMW X1 1.6L,Essence,126000.0,2016
+138500,BMW Série 1 M,Essence,40000.0,2022
+58500,Citroën Berlingo Utilitaire 1.6L,Diesel,31000.0,2023
+38000,Citroën C3,Essence,92000.0,2018
+34500,Citroën C3 Live,Essence,119000.0,2019
+38000,Citroën C4,Essence,109000.0,2012
+88000,Peugeot 3008 Allure,Essence,38000.0,2019
+159000,Mercedes-Benz Classe C Avantgarde,Essence,27000.0,2022
+75000,Peugeot 3008 Allure,Essence,75000.0,2020
+139000,BMW X4,Diesel,140000.0,2018
+65500,Volkswagen Polo R-Line,Essence,70000.0,2020
+69000,Volkswagen Golf 7 BVA,Essence,200000.0,2020
+75000,BMW Série 1 Pack Sport M,Essence,165000.0,2016
+147000,Hyundai Tucson Top Grade,Essence,40000.0,2022
+41000,Lada 4x4 Urban,Essence,58000.0,2020
+205000,Mercedes-Benz Classe X,Diesel,68000.0,2020
+81000,Seat Arona Xperience,Essence,47000.0,2022
+69000,Toyota Corolla Dynamic,Essence,85000.0,2020
+65000,Fiat 500X Pop Star,Essence,60000.0,2018
+115000,Land Rover Discovery,Essence,170000.0,2015
+88000,Haval Jolion,Essence,40000.0,2021
+73000,Toyota C-HR,Essence,130000.0,2018
+92500,Nissan Juke Tekna,Essence,6000.0,2024
+255100,Mercedes-Benz Classe C AMG,Essence,20000.0,2023
+129000,Mercedes-Benz CLA Kit Amg 200,Essence,150000.0,2020
+62000,Seat Ibiza Xcellence,Essence,68000.0,2021
+57500,KIA Rio 5p SX,Essence,70000.0,2020
+72000,MG ZS Luxury,Essence,20000.0,2022
+101000,Chery Tiggo 7 Pro,Essence,0.0,2024
+165000,Audi Q3 BVA,Essence,3000.0,2023
+155000,Peugeot 408 GT,Essence,10000.0,2024
+87000,Jaguar XF Luxury,Essence,120000.0,2014
+85000,BMW Série 6 Face Lift,Essence,190000.0,2009
+189000,Land Rover Range Rover Sport HSE Dynamic,Diesel,300000.0,2016
+62000,KIA Rio 5p GT-Line,Essence,70000.0,2021
+188000,KIA Sportage GT-Line,Hybride,15000.0,2024
+225000,Mercedes-Benz GLA 250e Pack AMG,Hybride,26000.0,2023
+39000,Mahindra Pick-up SC,Diesel,120000.0,2021
+69000,Peugeot 3008,Essence,112000.0,2020
+73000,KIA Rio 5p GT-Line,Essence,9000.0,2023
+152000,Mercedes-Benz Classe C Pack AMG Pack night,Hybride,120000.0,2019
+89000,Peugeot 3008 GT GT-line,Essence,125000.0,2020
+77900,MG HS Luxury,Essence,87000.0,2020
+173000,Mercedes-Benz GLA AMG,Essence,90000.0,2021
+87000,BMW Série 4 Coupé 420i,Essence,180000.0,2015
+88000,Chery Tiggo 7 Pro,Essence,40000.0,2022
+98000,Suzuki Jimny,Essence,20000.0,2023
+83000,Mercedes-Benz CLA Kit AMG,Essence,124000.0,2014
+37500,Citroën C3 Shine,Essence,88000.0,2018
+63000,Mercedes-Benz Classe C coupé AMG,Essence,200000.0,2012
+45000,Renault Clio 4,Essence,120000.0,2021
+29000,Mini 3 portes One,Essence,200000.0,2009
+129000,Hyundai Tucson High Grade,Essence,19000.0,2023
+87000,Nissan Juke Tekna,Essence,53000.0,2021
+88000,Jeep Renegade,Essence,88000.0,2021
+152000,Mercedes-Benz Classe C AMG,Hybride,120000.0,2019
+109000,Ford Mondeo Hybride,Hybride,34000.0,2020
+120000,Land Rover Range Rover Evoque,Diesel,145000.0,2018
+59000,Volkswagen Passat,Essence,160000.0,2016
+117000,Haval H6,Essence,16000.0,2022
+85000,Haval H6 Luxury,Essence,55000.0,2021
+105000,Volkswagen Golf 8 1.4,Essence,40000.0,2022
+179000,Jaguar F-Pace R_Dynamic,Diesel,165000.0,2017
+70000,Renault Kadjar,Essence,140000.0,2018
+79000,Toyota Corolla,Essence,24000.0,2022
+47000,Peugeot 308,Essence,128000.0,2020
+167000,Mercedes-Benz Classe C coupé AMG,Essence,130000.0,2018
+47500,Citroën C3 Shine,Essence,45000.0,2020
+40000,Ford Focus Titanium,Essence,200000.0,2015
+178000,Porsche Panamera,Essence,82000.0,2011
+89000,KIA Seltos,Essence,130000.0,2021
+81000,Seat Ibiza FR,Essence,40000.0,2023
+77000,Alfa Romeo Giulietta,Essence,37000.0,2019
+235000,Land Rover Discovery R-DYNAMIC,Diesel,87000.0,2020
+49000,Volkswagen Golf 7 Confortline,Essence,190000.0,2013
+64500,Renault Megane 4 Diesel,Diesel,125000.0,2020
+65000,KIA Rio 5p GT-Line,Essence,60000.0,2021
+35000,Fiat Fiorino,Diesel,120000.0,2021
+75000,Dacia Duster Techroad,Essence,35000.0,2020
+278000,BMW Série 5 530e Xdrive Pack m,Hybride,50000.0,2021
+97000,BMW Série 4 Gran Coupé 418 Luxury,Essence,133000.0,2016
+125000,Volkswagen Passat R-Line DSG,Essence,40000.0,2022
+290000,Toyota Hilux Double Cabine Gr Sport,Diesel,7000.0,2024
+91000,Toyota C-HR,Essence,55000.0,2022
+109000,Audi A5 Sportback S-Line,Essence,120000.0,2019
+80000,Peugeot 2008,Diesel,100000.0,2021
+59700,KIA Rio 5p,Essence,85000.0,2022
+91000,Honda CR-V,Essence,67000.0,2018
+295000,Audi Q5 S-line,Diesel,40000.0,2021
+107000,KIA Sportage Hybride,Hybride,114000.0,2021
+128000,KIA Sportage GT-Line,Diesel,19000.0,2021
+76000,Dacia Duster Techroad,Essence,34000.0,2020
+660000,Mercedes-Benz Classe S AMG,Hybride,3000.0,2022
+455000,BMW X5 Hybride Xdrive E45,Hybride,19000.0,2021
+138000,Hyundai Tucson Hybride Xcellence,Hybride,120000.0,2022
+75000,BMW Série 1 I Pack Sport,Essence,200000.0,2019
+105000,KIA Sportage GT-Line,Diesel,140000.0,2017
+235000,Mercedes-Benz Classe C AMG,Essence,50000.0,2023
+120000,Jaguar XE,Diesel,140000.0,2017
+72000,Peugeot Rifter,Diesel,95000.0,2020
+110000,BMW Série 7 740LI,Essence,98000.0,2010
+72000,Peugeot Rifter 5 places,Diesel,95000.0,2020
+187000,Land Rover Range Rover Evoque Hybride,Diesel,50000.0,2019
+115000,Ford Mondeo Hybride,Hybride,32000.0,2020
+64000,KIA Rio 5p GT-Line,Essence,64000.0,2021
+169000,Mercedes-Benz GLC AMG,Essence,115000.0,2017
+57000,Mini 5 portes One,Essence,78000.0,2016
+48000,Citroën C3 Shine,Essence,28000.0,2020
+85000,Audi A3 Berline,Essence,50000.0,2019
+83500,KIA Sportage,Essence,127000.0,2019
+235000,Mercedes-Benz GLA AMG,Essence,12000.0,2023
+95000,Audi Q3,Essence,95000.0,2017
+210000,Mercedes-Benz GLB 200 d,Diesel,111000.0,2021
+58000,Audi A4 Face_lift,Essence,143000.0,2016
+95000,Land Rover Range Rover Evoque Face_lift,Essence,170000.0,2016
+135000,BMW Série 1 Pack M,Essence,40000.0,2020
+195000,Land Rover Range Rover Evoque Hybride,Diesel,40000.0,2019
+79000,Haval H6 Luxury,Essence,120000.0,2020
+105000,Iveco Daily Simple Cabine,Diesel,40000.0,2022
+128000,Land Rover Discovery Sport,Diesel,128000.0,2017
+90000,Haval H6 Luxury,Essence,40000.0,2021
+98000,KIA Sportage Hybride,Hybride,140000.0,2020
+85000,KIA Sportage,Essence,125000.0,2019
+137000,Hyundai Tucson Hybride,Hybride,80000.0,2021
+165000,Audi Q5 QUATTRO 40 TDI,Diesel,170000.0,2019
+43500,Fiat Panda City Cross,Essence,52000.0,2020
+45000,Volkswagen Golf 6 Match,Diesel,240000.0,2012
+228000,Ford Ranger Raptor,Diesel,100000.0,2022
+130000,BMW Série 4 Coupé Pack M,Essence,140000.0,2021
+48000,Mercedes-Benz Classe B,Essence,100000.0,2014
+75000,MG ZS Luxury,Essence,80000.0,2022
+210000,Land Rover Range Rover Evoque Hybride,Diesel,60000.0,2019
+68000,Renault Kadjar,Essence,70000.0,2019
+56000,Mazda 3 Sky active,Essence,103000.0,2017
+398000,Audi Q8 S_Line,Essence,16000.0,2021
+173000,Mercedes-Benz Classe C coupé AMG,Essence,50000.0,2019
+78000,MG ZS,Essence,35000.0,2022
+40000,Suzuki Baleno,Essence,160000.0,2017
+95000,KIA Sportage,Essence,69000.0,2019
+69000,Ford Kuga,Essence,100000.0,2017
+119000,Mercedes-Benz CLS AMG,Diesel,160000.0,2011
+185000,Mercedes-Benz GLA 180 Pack AMG,Essence,40000.0,2022
+73500,Seat Arona,Essence,26000.0,2021
+71000,Toyota Corolla,Essence,90000.0,2021
+79000,Haval H6 Luxury,Essence,115000.0,2020
+125000,Skoda Superb Ambassador,Essence,30000.0,2021
+79000,MG 6,Essence,22000.0,2021
+189000,Mercedes-Benz GLC Coupé AMG,Diesel,190000.0,2017
+89000,Mercedes-Benz Classe C 180 elegance,Essence,170000.0,2016
+278000,Mercedes-Benz GLC Coupé AMG,Hybride,69000.0,2020
+135000,Mercedes-Benz Classe E 180,Essence,90000.0,2018
+42000,Ssangyong Actyon Sports,Diesel,200000.0,2017
+35000,DS 3,Essence,138000.0,2012
+97000,Audi A3 Berline,Essence,17000.0,2020
+43000,Nissan Qashqai,Essence,147000.0,2011
+90000,BMW Série 5 Confort Luxury,Essence,200000.0,2015
+101000,Volkswagen Passat R-Line,Essence,100000.0,2019
+125000,Land Rover Discovery Sport,Diesel,160000.0,2017
+44500,Citroën C3 Shine,Essence,90000.0,2019
+49000,Volkswagen Amarok,Diesel,370000.0,2012
+291800,Mercedes-Benz Classe E Business,Essence,8000.0,2022
+37000,Mini 3 portes one,Essence,140000.0,2013
+68000,BMW Série 1,Essence,126000.0,2017
+231000,Toyota Hilux Double Cabine 4*4,Essence,3000.0,2024
+97000,Peugeot 2008 Allure,Essence,34000.0,2022
+158000,Mercedes-Benz Classe A AMG,Essence,20000.0,2022
+106000,Volkswagen Passat R-Line,Essence,60000.0,2020
+90000,Volkswagen Tiguan,Essence,60000.0,2018
+99000,Mercedes-Benz Classe C AMG,Essence,160000.0,2014
+96000,Chery Tiggo 8 Pro,Essence,80000.0,2022
+47000,BYD F3,Essence,10000.0,2022
+44500,Citroën C3 Shine,Essence,58000.0,2019
+107000,BMW Série 4 Coupé 420i Pack M,Essence,160000.0,2015
+90000,Audi Q3 S-line,Essence,100000.0,2017
+109000,Volkswagen Golf 8 United,Essence,26000.0,2020
+35000,Peugeot 208,Essence,60000.0,2020
+59000,Audi A5 Cabriolet S-line,Essence,120000.0,2010
+135000,Honda Accord,Essence,11000.0,2022
+74000,Volkswagen Golf 7,Essence,40000.0,2019
+119000,KIA Sportage,Essence,40000.0,2020
+135000,BMW Série 2 Gran Coupé 218i,Essence,21000.0,2022
+46000,Fiat Tipo 5 portes,Essence,75000.0,2018
+150600,Haval H6,Essence,13000.0,2022
+52000,Volkswagen Golf 7 Smartline,Essence,140000.0,2015
+78000,Haval H6 Luxury,Essence,90000.0,2019
+40000,Chevrolet Cruze,Essence,90000.0,2018
+76000,Volkswagen Golf 7,Essence,29000.0,2019
+51000,Mercedes-Benz Classe E 200,Essence,330000.0,2010
+77000,Mercedes-Benz Classe E e220,Diesel,330000.0,2011
+145000,Volkswagen Golf 8 R-Line,Essence,40000.0,2021
+240000,Mercedes-Benz Classe C AMG,Essence,16000.0,2023
+212000,Dodge RAM Rumble bee,Essence,65000.0,2019
+81000,Mercedes-Benz CLA,Essence,163000.0,2014
+69000,Haval H2 Luxury,Essence,40000.0,2019
+86000,Haval H6 Luxury,Essence,32000.0,2019
+169000,Mercedes-Benz CLA AMG,Essence,30000.0,2021
+98000,Mercedes-Benz Classe A 180d,Diesel,50000.0,2019
+74000,Volkswagen Golf 7,Essence,64000.0,2019
+95000,Audi A3 Sportback S-Line,Essence,70000.0,2019
+205000,Mercedes-Benz Classe C AMG,Essence,40000.0,2022
+105000,DS 7 Crossback Grand Chic,Essence,140000.0,2021
+264200,Mercedes-Benz Classe C AMG,Essence,50000.0,2022
+84000,Volkswagen Golf 7 Join,Essence,70000.0,2018
+79000,Mercedes-Benz CLA 220,Diesel,240000.0,2013
+110000,BMW X6 Pack M,Diesel,270000.0,2008
+59000,Audi A5 Cabriolet S-line,Essence,120000.0,2010
+73000,Seat Leon Style,Essence,65000.0,2020
+37500,Citroën Berlingo Utilitaire,Diesel,170000.0,2018
+143000,KIA Sportage,Essence,23000.0,2022
+64000,Volkswagen Golf 7,Essence,180000.0,2019
+78000,Mercedes-Benz Classe S Executive,Essence,170000.0,2008
+128000,Volkswagen Tiguan Confortline,Essence,33000.0,2020
+80000,Volkswagen Golf 7 R-Line,Essence,130000.0,2018
+79000,Hyundai Kona,Hybride,30000.0,2021
+122800,Seat Leon FR,Essence,70000.0,2022
+53000,Hyundai Grand i10,Essence,30000.0,2022
+92000,Peugeot 2008 GT_LINE,Essence,30000.0,2021
+179000,Mercedes-Benz Classe C coupé AMG,Essence,40000.0,2019
+119000,KIA Sportage GT-Line,Hybride,120000.0,2021
+88000,BMW Série 3 318i,Essence,117000.0,2017
+43500,Chery Tiggo 2 Confort,Essence,60000.0,2020
+87000,Haval Jolion,Essence,40000.0,2022
+208000,Mercedes-Benz Classe C AMG,Essence,40000.0,2022
+53000,Hyundai Grand i10,Essence,54000.0,2021
+68000,Seat Ibiza FR,Essence,100000.0,2020
+169000,Mercedes-Benz CLA AMG,Essence,20000.0,2020
+67000,Seat Ibiza FR,Essence,50000.0,2020
+85000,Volkswagen T-roc,Essence,87000.0,2020
+113000,Mercedes-Benz GLA AMG,Essence,74000.0,2016
+115000,Mercedes-Benz Classe C AMG,Essence,170000.0,2014
+188000,Audi Q3 Sportback,Essence,10000.0,2021
+215000,Audi Q5,Diesel,100000.0,2018
+125000,Volkswagen Golf 8 R-Line,Essence,70000.0,2021
+185000,Jaguar F-Pace R-DYNAMIC,Diesel,165000.0,2017
+77000,Peugeot 3008 GT-line,Essence,260000.0,2017
+350000,Land Rover Range Rover Velar R-Dynamic,Diesel,100000.0,2019
+255000,Porsche Panamera PLATINUM édition,Essence,100000.0,2014
+295000,Land Rover Range Rover Velar R-Dynamic,Essence,90000.0,2020
+182900,Dongfeng Forthing T5 EVO,Essence,4000.0,2023
+47000,Chery Tiggo 3,Essence,75000.0,2018
+85000,Audi Q3,Essence,77000.0,2017
+66000,Renault Kadjar Intens,Essence,150000.0,2018
+155000,Volkswagen Golf 8 R-Line,Essence,40000.0,2021
+205000,Mercedes-Benz Classe C AMG,Hybride,35000.0,2020
+80000,Volkswagen Golf 7 Join,Essence,120000.0,2019
+99000,BMW Série 4 Gran Coupé Luxury,Essence,100000.0,2018
+161000,Hyundai Tucson,Essence,24000.0,2023
+87000,Hyundai Tucson,Essence,120000.0,2020
+92000,BMW Série 1 Pack sport,Essence,70000.0,2020
+45000,Fiat Panda City Cross,Essence,20000.0,2022
+125000,BMW Série 4 Gran Coupé 418 PACK M,Essence,110000.0,2017
+77000,Mercedes-Benz Classe E AMG,Essence,135000.0,2011
+215000,Mercedes-Benz Classe C AMG,Essence,80000.0,2022
+65000,Dongfeng SX3,Essence,30000.0,2021
+128000,Volkswagen Golf 8 United,Essence,16000.0,2021
+172000,Mercedes-Benz Classe A AMG,Essence,15000.0,2022
+148000,Mercedes-Benz Classe C AMG,Diesel,80000.0,2019
+62000,MG GS Luxe,Essence,115000.0,2017
+122800,Mitsubishi ASX 4WD,Essence,55000.0,2021
+126000,Land Rover Discovery,Diesel,130000.0,2017
+185000,Audi A5 Sportback,Essence,70000.0,2021
+45000,BMW Série 7 Individuel,Essence,300000.0,2008
+245000,Land Rover Range Rover Sport,Diesel,160000.0,2014
+110000,BMW Série 4 Coupé,Essence,78000.0,2017
+61000,MG GS Luxe Plus,Essence,100000.0,2017
+40000,Peugeot RCZ,Essence,171000.0,2011
+118000,Land Rover Discovery Sport,Diesel,94000.0,2016
+87000,Volkswagen Amarok AWD,Diesel,180000.0,2016
+55000,BMW Série 7 740I FACE-LIFT,Essence,220000.0,2008
+69000,Ford Ecosport Titanium,Essence,67000.0,2022
+120000,Toyota Corolla Cross Hybride High,Hybride,36000.0,2022
+58000,MG ZS Confort Plus,Essence,141000.0,2019
+85000,KIA Sportage,Essence,150000.0,2019
+74000,BMW Série 3 coupé Kit M///,Essence,152000.0,2012
+71000,Mercedes-Benz Classe C AMG,Essence,200000.0,2011
+75000,Audi A5 Coupé,Essence,109000.0,2014
+58500,KIA Rio 5p SX,Essence,35000.0,2020
+36500,BMW Série 1 Business Line,Essence,251000.0,2012
+78000,Volkswagen Golf 7 Sound,Essence,125000.0,2018
+170000,Mercedes-Benz CLA AMG,Hybride,25000.0,2021
+135000,Mercedes-Benz Classe A AMG,Hybride,35000.0,2020
+50000,Peugeot 308,Essence,102000.0,2020
+67000,Ford Ecosport Titanium,Essence,44000.0,2022
+62000,Fiat 500 Cult Club,Essence,3000.0,2023
+115000,Mercedes-Benz Classe A AMG,Essence,60000.0,2021
+110000,Volkswagen Tiguan R-Line,Essence,160000.0,2019
+40000,Volkswagen Scirocco,Essence,200000.0,2010
+115000,Audi A5 Sportback,Essence,80000.0,2019
+100000,Hyundai Tucson,Diesel,81000.0,2018
+125000,Land Rover Discovery,Essence,110000.0,2016
+110000,Mercedes-Benz Classe A,Essence,90000.0,2021
+178000,Hyundai Tucson Hybride Top Grade,Diesel,16000.0,2023
+51000,Peugeot 508,Essence,145000.0,2018
+145000,Mercedes-Benz Classe C coupé AMG,Essence,120000.0,2019
+230000,Land Rover Range Rover Sport,Diesel,90000.0,2017
+220000,Porsche Cayenne,Essence,158000.0,2015
+67000,BMW Série 3,Essence,210000.0,2015
+108000,Mercedes-Benz Classe A,Essence,50000.0,2020
+66000,Mercedes-Benz Classe C,Essence,180000.0,2013
+83000,Renault Kadjar,Essence,98000.0,2021
+85000,Land Rover Range Rover Sport,Diesel,208000.0,2007
+200000,Audi Q3,Hybride,40000.0,2023
+95000,KIA Sorento,Diesel,120000.0,2016
+118000,KIA Sportage,Diesel,140000.0,2018
+53000,KIA Rio 5p SX PLUS,Essence,99000.0,2020
+47100,Wallyscar 719,Essence,86573.0,2023
+61000,Renault Megane Sedan,Essence,46000.0,2019
+78000,Ford Ecosport,Essence,19000.0,2022
+58000,Mercedes-Benz ML,Diesel,250000.0,2007
+36000,Ford Focus Trend Sport,Essence,180000.0,2014
+65000,Toyota Prado Adventure,Diesel,330000.0,1999
+27500,Peugeot 207 Access Plus,Diesel,290000.0,2011
+145000,Mercedes-Benz CLA,Diesel,60000.0,2021
+63500,Hyundai ix35 Toit Panoramique,Diesel,160000.0,2016
+41300,Volkswagen Polo Sedan Trendline,Essence,170000.0,2020
+68500,Mercedes-Benz Classe A AMG,Essence,180000.0,2014
+420000,Mercedes-Benz GLC Coupé AMG,Essence,0.0,2024
+105000,Mercedes-Benz Classe C,Essence,200000.0,2014
+65000,Ssangyong Tivoli Confort Plus,Essence,4700.0,2018
+63000,Mini 3 portes John Cooper Works,Essence,100000.0,2017
+168000,Toyota Hilux Double Cabine D4D,Diesel,140000.0,2020
+255000,Land Rover Range Rover Evoque HSE,Hybride,60000.0,2022
+132000,Mercedes-Benz Classe A Berline AMG,Essence,100000.0,2020
+385000,Land Rover Range Rover Sport Autobiography,Hybride,60000.0,2021
+220000,Mercedes-Benz CLA AMG,Essence,0.0,2024
+480000,Porsche Cayenne Coupé GTS,Hybride,70000.0,2020
+450000,Mercedes-Benz GLE Coupé,Hybride,30000.0,2022
+260000,Mercedes-Benz Classe E AMG,Hybride,70000.0,2020
+270000,Mercedes-Benz GLC Coupé AMG,Hybride,80000.0,2021
+145000,BMW Série 4 Gran Coupé KIT-M-individual,Essence,120000.0,2016
+115000,Mercedes-Benz CLA,Diesel,130000.0,2017
+145000,Audi A3 Sportback 1.5,Hybride,900.0,2023
+190000,Tesla Model 3 Modèle 3 Highland 2024,Electrique,15000.0,2023
+197000,Mercedes-Benz GLC AMG,Hybride,130000.0,2018
+168000,Mercedes-Benz Classe E,Diesel,158000.0,2020
+56000,Nissan Qashqai,Diesel,147000.0,2016
+145000,Hyundai Tucson,Essence,37000.0,2022
+95000,Audi Q2 Design,Essence,77000.0,2019
+62000,KIA Rio 5p,Essence,51000.0,2021
+85000,Toyota C-HR,Essence,71000.0,2021
+78000,KIA Sportage Black Edition,Essence,117000.0,2018
+26000,Mahindra KUV 100 K6+,Essence,90000.0,2021
+75000,Toyota C-HR,Essence,165000.0,2020
+28000,Ford Fiesta Trend,Essence,161000.0,2013
+150000,BMW Série 4 Coupé M,Essence,85000.0,2019
+60000,Renault Megane Sedan,Essence,70000.0,2021
+104000,Mazda CX-9 High grade,Essence,155000.0,2019
+29500,Ford Fiesta Titanium,Essence,223000.0,2013
+26000,Peugeot Partner,Diesel,320000.0,2009
+37900,Suzuki Celerio,Essence,45000.0,2022
+144900,Mercedes-Benz CLA AMG,Essence,100000.0,2020
+90000,MG HS Trophy,Essence,111000.0,2022
+41500,Seat Ibiza,Essence,83000.0,2019
+48000,Ssangyong Tivoli,Essence,235000.0,2018
+32500,Mahindra KUV 100 K6+,Essence,59000.0,2022
+18000,Hyundai H-1,Essence,999999.0,2006
+29500,Nissan Micra,Essence,130000.0,2017
+28600,BMW Serie 1,Essence,240000.0,2007
+25800,Fiat Doblo,Diesel,160000.0,2020
+78000,Mercedes-Benz Classe C,Essence,207600.0,2014
+39500,Kia Cerato,Essence,14400.0,2015
+55500,Kia Rio,Essence,90000.0,2021
+44500,Volkswagen Polo,Essence,140000.0,2021
+30500,Renault Clio,Essence,116000.0,2012
+950,Citroen C5,Essence,250.0,2024
+17500,Peugeot 207,Essence,229999.0,2012
+20000,Citroen Nemo,Diesel,420000.0,2014
+13500,Peugeot 306,Essence,202000.0,2000
+34000,Citroen C3,Essence,97000.0,2018
+29000,SsangYong Actyon,Diesel,424000.0,2015
+9000,Opel Corsa,Essence,312.0,N.C
+1111,Volkswagen Golf 5,Essence,170000.0,2007
+66500,Peugeot 3008,Essence,100000.0,2019
+78000,Peugeot Partner,Diesel,70000.0,2020
+41500,Skoda Fabia,Essence,130000.0,2021
+105000,BMW Serie 4,Essence,150000.0,2019
+152000,BMW X4,Essence,62000.0,2016
+53000,Fiat Tipo,Essence,113000.0,2020
+48500,Renault Megane,Essence,150000.0,2020
+79000,Ford Focus,Essence,60000.0,2020
+82000,Nissan Juke,Essence,27000.0,2023
+44000,Peugeot 2008,Essence,117000.0,2018
+33800,Nissan Micra,Essence,74300.0,2020
+67000,Mercedes-Benz Classe E,Essence,197000.0,2010
+55000,Audi A6,Essence,166920.0,2016
+41000,Hyundai i10,Essence,65000.0,2023
+96000,Kia Sportage,Essence,45000.0,N.C
+1111,Jeep Compass,Essence,64000.0,2020
+1111,BMW Serie 4,Essence,150000.0,2019
+1111,Land Rover Range Rover Sport,Hybride,42000.0,2020
+38500,Fiat Panda,Essence,130000.0,2022
+42000,Ford Focus,Essence,120000.0,2016
+75000,Kia Sportage,Essence,160000.0,2017
+45500,Fiat 500C,Essence,71000.0,2017
+61500,Citroen DS5,Essence,110000.0,2017
+42000,Citroen C3,Essence,98270.0,2018
+117000,Kia Sportage,N.C,54000.0,2020
+58000,Volkswagen Passat,Essence,140000.0,2016
+54000,Peugeot 2008,Essence,90000.0,2019
+22800,Chery QQ,Essence,104000.0,2019
+45500,Peugeot 208,Essence,78000.0,2021
+78000,Audi A3,Essence,98000.0,2020
+13500,Opel Corsa,Essence,266000.0,2000
+70000,SEAT Leon,Essence,61847.0,2019
+35500,Citroen C3,Essence,58000.0,2021
+46500,Kia Picanto,Essence,28000.0,2021
+90000,MG ZS,Essence,13.0,2024
+47000,Nissan Navara,Diesel,315000.0,2012
+30000,Peugeot 508,Essence,268000.0,2012
+40500,Renault Clio,Essence,110000.0,2016
+19500,Renault Megane,Diesel,350000.0,2007
+48500,Kia Rio,Essence,170000.0,2021
+42500,Renault Clio,Essence,80000.0,2021
+8500,Renault Clio,Essence,300000.0,1993
+400,Renault Clio,Essence,,2023
+36500,Citroen C-Elysee,Essence,70000.0,2020
+52000,Volkswagen Polo,Essence,,2022
+120000,Mazda BT-50,Essence,190000.0,2015
+26000,Nissan Micra,Essence,160000.0,2013
+61500,Kia Rio,Essence,48000.0,2024
+12800,Opel Corsa,Essence,350000.0,2000
+46000,Mazda CX-9,Essence,286000.0,2010
+41000,Renault Clio,Essence,91300.0,2020
+61000,SsangYong Tivoli,Essence,74000.0,2020
+77500,Mercedes-Benz Classe CLA,Essence,170000.0,2014
+67500,BMW X5,Diesel,280000.0,2008
+40900,Toyota Aygo,Essence,90000.0,2021
+9000,Peugeot 205,Essence,111000.0,1993
+27500,Peugeot 207,Diesel,290000.0,2011
+1000,Renault R4,Essence,57000.0,1980
+10000,Renault Clio,Essence,123000.0,2005
+190000,Hyundai Santa Fe,Diesel,48000.0,2020
+19000,Peugeot 206,Essence,,2001
+32000,Fiat Fiorino,Diesel,112000.0,2019
+173000,Mercedes-Benz Classe C,Essence,9000.0,2021
+27000,Chevrolet Spark,Essence,121000.0,2015
+35000,Peugeot 308,Essence,168000.0,2015
+37000,SEAT Ibiza,Essence,205000.0,2020
+51500,Hyundai i20,Essence,72000.0,2022
+19700,Citroen C3,Essence,195540.0,2007
+85000,Toyota C-HR,Essence,711000.0,2021
+25000,Volkswagen Polo,Essence,47000.0,2006
+33000,Hyundai i10,Essence,88000.0,2018
+38500,Citroen Berlingo,Diesel,76470.0,2015
+220000,Mercedes-Benz Classe A,Essence,10000.0,2002
+64000,Volkswagen Caddy,Diesel,124000.0,2020
+33000,Peugeot Partner,Diesel,282000.0,2016
+65000,BMW X5,Essence,154000.0,2009
+30000,Peugeot 208,Essence,113000.0,2017
+56000,Volkswagen Passat,Diesel,300000.0,2013
+75000,Toyota C-HR,Essence,165000.0,2020
+60000,Renault Megane,Essence,60000.0,2021
+25000,Mercedes-Benz Classe A,Essence,100000.0,2002
+8000,Peugeot 206,Diesel,,2003
+22000,Peugeot 301,Essence,106000.0,2014
+24500,Peugeot 301,Essence,170000.0,2015
+42500,Suzuki Swift,Essence,49500.0,2019
+42300,Kia Picanto,Essence,74000.0,2020
+40000,Kia Picanto,Essence,77000.0,2021
+26500,Fiat Grande Punto,Essence,194500.0,2014
+32000,Peugeot 308,Essence,180000.0,2015
+43000,Renault Clio,Essence,105000.0,2020
+24800,Renault Clio,Essence,200000.0,2010
+42500,Volkswagen Polo,Essence,92500.0,2021
+28000,Volkswagen Passat,Diesel,,2000
+15500,Chevrolet Aveo,Essence,258000.0,2005
+15500,Renault Symbol,Essence,390000.0,2010
+175000,Volkswagen Golf 7,Essence,75000.0,2020
+33500,BMW Serie 3,Essence,248000.0,2007
+38000,Hyundai Accent,Essence,141000.0,2016

--- a/clean_data/preset1_mileage_fixed.csv
+++ b/clean_data/preset1_mileage_fixed.csv
@@ -1,0 +1,829 @@
+Price,Title,Fuel,Mileage,Year
+35 000,KIA Rio Berline,Essence,163746.0,2016
+105 000,Peugeot 3008,Essence,55000.0,2022
+30 500,Renault Clio Campus climatisée,Essence,116000.0,2012
+52 000,Chery Tiggo 3X Luxury,Essence,47000.0,2022
+32 000,Peugeot 3008,Essence,210000.0,2010
+52 000,KIA Rio Berline,Essence,90500.0,2020
+43 500,Hyundai Grand i10,Essence,43200.0,2021
+58 000,MG 5,Essence,37000.0,2022
+73 500,Mercedes-Benz Classe C,Essence,159000.0,2012
+260 000,Mercedes-Benz GLC Coupé AMG,Hybride,47000.0,2021
+77 000,Haval H6 Luxury,Essence,100000.0,2019
+67 000,Mercedes-Benz Classe E,Essence,197000.0,2010
+178 000,Mercedes-Benz Classe C coupé AMG,Hybride,86000.0,2019
+122 000,Land Rover Range Rover Evoque R-Dynamic,Diesel,150000.0,2016
+145 000,BMW Série 4 Gran Coupé,Essence,90000.0,2019
+258 000,Land Rover Range Rover Velar R-Dynamic,Diesel,55000.0,2020
+189 000,Mercedes-Benz GLA AMG,Essence,20000.0,2023
+97 500,Hyundai Kona Hybride N Line,Hybride,19500.0,2020
+112 000,Audi Q3,Essence,110000.0,2019
+152 000,Porsche Cayenne,Essence,195000.0,2012
+103 000,MG HS Trophy,Essence,35000.0,2021
+122 000,Mercedes-Benz Classe S S 350 phase 2,Essence,165000.0,2010
+Sous leasing                    161 300,Mercedes-Benz Classe C AMG,Essence,135000.0,2019
+72 000,Volkswagen Golf 7 Join,Essence,83000.0,2018
+98 000,Mercedes-Benz Classe S S350. Toit ouvrant,Essence,147000.0,2009
+56 000,Peugeot Partner Origin Utilitaire Pack Clim PM,Diesel,73000.0,2019
+95 000,KIA Sportage GT-Line,Diesel,139000.0,2018
+155 000,Cupra Formentor Sport,Essence,41000.0,2022
+165 000,Mercedes-Benz Classe C AMG,Hybride,54000.0,2018
+165 000,Mercedes-Benz Classe C AMG,Hybride,69000.0,2020
+75 000,Volkswagen Golf 7 Confortline,Essence,69000.0,2020
+51 000,KIA Rio 5p,Essence,145000.0,2019
+145 000,Mercedes-Benz Classe A,Hybride,66000.0,2021
+95 000,Volkswagen Golf 7,Essence,88000.0,2018
+55 000,BMW Série 1,Essence,144000.0,2015
+76 500,Volkswagen Golf 7 Join,Essence,120000.0,2020
+199 000,BMW X2 Lounge,Essence,0.0,2024
+169 000,Land Rover Range Rover Evoque R-Dynamic,Diesel,59000.0,2021
+110 000,Volkswagen Golf 8 R-Line,Hybride,12000.0,2022
+122 000,Mercedes-Benz GLA AMG,Essence,30000.0,2018
+259 000,Mercedes-Benz GLC Coupé AMG,Hybride,50000.0,2021
+174 000,Mercedes-Benz Classe C AMG +,Essence,60000.0,2021
+155 000,Volkswagen T-roc 1.5,Hybride,9000.0,2024
+197 000,Mercedes-Benz Classe C AMG,Essence,32000.0,2022
+218 000,Land Rover Range Rover Evoque R-Dynamic S,Hybride,59000.0,2021
+115 000,Volkswagen Golf 8,Hybride,40000.0,2020
+248 000,Mercedes-Benz Classe C AMG +,Hybride,11000.0,2024
+89 500,Suzuki Jimny,Essence,60000.0,2021
+68 000,Mercedes-Benz Classe E coupé AMG,Essence,180000.0,2010
+98 000,Volkswagen T-roc Toit ouvrant,Essence,44000.0,2020
+99 500,Mercedes-Benz Classe C AMG,Essence,180000.0,2016
+184 000,Mercedes-Benz GLB AMG,Essence,16000.0,2023
+435 000,Mercedes-Benz Classe E AMG,Hybride,0.0,2024
+109 000,Mercedes-Benz Classe C AMG,Essence,175000.0,2016
+124 500,BMW Série 5 Luxury Line,Essence,155000.0,2017
+169 000,Mercedes-Benz Classe A A200,Hybride,8000.0,2024
+149 000,KIA Sportage GT-Line,Hybride,40000.0,2023
+268 000,Land Rover Range Rover Velar R-Dynamic,Essence,33000.0,2019
+158 000,BMW Série 7 B7 ALPINA,Essence,115000.0,2011
+89 500,Volkswagen Golf 8 ÉDITION,Essence,45000.0,2021
+450 000,Mercedes-Benz Classe E AMG,Hybride,0.0,2024
+415 000,Mercedes-Benz GLC Coupé AMG,Essence,0.0,2024
+169 000,Mercedes-Benz CLA AMG,Hybride,42000.0,2020
+295 000,Audi Q5 Sportback S-Line,Hybride,45000.0,2022
+124 000,Mercedes-Benz Classe A A 200,Essence,57000.0,2018
+188 000,Mercedes-Benz CLA AMG,Essence,30000.0,2023
+178 000,Land Rover Range Rover Sport,Essence,180000.0,2014
+535 000,Porsche Panamera 4S E-hybride plugin,Hybride,32000.0,2021
+225 000,Mercedes-Benz GLC Coupé AMG,Essence,106000.0,2016
+175 000,Audi Q3 Sportback hybrid,Hybride,50000.0,2021
+380 000,Porsche Cayenne Coupé,Essence,37000.0,2020
+269 000,Jaguar F-Pace R-Dynamic S,Essence,27000.0,2021
+129 000,BMW X1 FACELIFT PACK M,Essence,87000.0,2020
+168 000,Mitsubishi L200 Sportero,Diesel,19000.0,2022
+510 000,Porsche Cayenne,Hybride,15000.0,2022
+147 000,Audi A5 Sportback S-Line,Essence,85000.0,2020
+88 000,Mercedes-Benz ML,Diesel,231000.0,2010
+148 000,Mercedes-Benz CLA,Diesel,93000.0,2020
+98 000,BMW X6,Essence,180000.0,2011
+245 000,Mercedes-Benz GLC Coupé,Hybride,70000.0,2020
+350 000,Mercedes-Benz Classe G,Diesel,168000.0,2010
+85 000,Peugeot 508,Essence,46000.0,2020
+132 000,Seat Leon Cupra,Essence,74000.0,2020
+48 000,Volkswagen Touareg,Diesel,308000.0,2006
+195 000,Mercedes-Benz Classe S,Hybride,79000.0,2015
+83 000,Peugeot 508,Essence,137000.0,2019
+340 000,Land Rover Range Rover Sport,Hybride,100000.0,2019
+178 000,BMW Série 5,Essence,93000.0,2020
+400 000,Mercedes-Benz GLC Coupé,Essence,0.0,2024
+208 000,BMW Série 5,Essence,32000.0,2021
+630 000,Mercedes-Benz Classe G AMG,Essence,30000.0,2015
+158 000,Mercedes-Benz GLC,Essence,83000.0,2016
+174 000,Mercedes-Benz CLA,Hybride,69000.0,2021
+30 500,Citroën DS3,Essence,92000.0,2017
+100 000,Mini Clubman,Essence,34000.0,2019
+450 000,Mercedes-Benz Classe S,Hybride,40000.0,2020
+95 000,Nissan Qashqai,Essence,26000.0,2022
+245 000,Mercedes-Benz Classe E,Essence,9000.0,2022
+360 000,Mercedes-Benz GLC Coupé,Essence,6600.0,2023
+170 000,Audi A5 Sportback,Essence,58000.0,2021
+98 000,Seat Ateca,Essence,85000.0,2020
+410 000,Porsche Cayenne E-Hybrid,Hybride,86000.0,2019
+54 500,KIA Picanto GT-Line,Essence,63000.0,2022
+88 000,Toyota Prado,Diesel,449000.0,2003
+47 000,BYD F3,Essence,10000.0,2022
+350 000,Land Rover Range Rover Sport,Hybride,37000.0,2020
+115 000,Volkswagen Golf 7,Essence,73000.0,2017
+375 000,Porsche Macan,Essence,6900.0,2023
+174 000,BMW Série 3,Essence,80000.0,2021
+190 000,Audi Q3,Essence,2000.0,2024
+370 000,Porsche Cayenne Coupé,Essence,59000.0,2019
+350 000,Toyota Land Cruiser,Diesel,98000.0,2016
+58 000,Mini 5 portes,Essence,75000.0,2015
+340 000,Mercedes-Benz Classe E coupé,Hybride,86000.0,2018
+82 000,Peugeot 3008,Essence,87000.0,2019
+56 000,Toyota RAV 4,Essence,280000.0,2016
+45 500,Fiat 500 C,Essence,71000.0,2017
+240 000,Mercedes-Benz GLC Coupé,Diesel,52000.0,2020
+42 000,Suzuki Swift,Essence,69000.0,2020
+76 000,Toyota Corolla,Essence,32000.0,2022
+92 500,Ssangyong Korando,Essence,80000.0,2021
+225 000,Jeep Wrangler Sahara,Essence,115000.0,2018
+40 000,Peugeot 2008 Allure,Essence,96000.0,2015
+100 000,BMW Série 4 Gran Coupé,Essence,121000.0,2019
+95 000,Volkswagen Tiguan,Essence,123000.0,2021
+59 000,BMW Série 3 318i,Essence,200000.0,2015
+25 500,Peugeot 307,Essence,110451.0,2007
+118 000,Mercedes-Benz Classe A AMG,Diesel,96000.0,2019
+139 500,Mini Countryman All4,Hybride,33000.0,2020
+58 000,MG ZS,Essence,110000.0,2021
+245 000,Mercedes-Benz Classe C,Essence,7300.0,2022
+120 000,KIA Sportage Hybride,Hybride,53000.0,2020
+115 000,BMW Série 1 Pack M,Essence,110.0,2020
+55 000,Fiat 500 Dolcevita,Hybride,78000.0,2021
+49 500,Fiat Tipo 5 portes,Essence,68000.0,2021
+49 500,Renault Clio,Diesel,138000.0,2020
+99 000,Mercedes-Benz Classe C,Essence,158000.0,2015
+39 500,Suzuki Celerio,Essence,0.0,2024
+48 500,Volkswagen Golf 7,Essence,153000.0,2015
+59 500,Renault Megane,Diesel,148000.0,2021
+45 500,Peugeot 208 Style,Diesel,128000.0,2020
+78 000,Audi Q5 S-line,Diesel,270000.0,2014
+38 500,Citroën C1 Importée Tn245,Essence,56000.0,2021
+76 000,Haval H6 Luxury,Essence,138000.0,2021
+79 000,Peugeot 3008,Diesel,148000.0,2020
+57 000,Volkswagen Amarok TDI 4*4,Diesel,198000.0,2012
+145 000,Mercedes-Benz CLA AMG,Diesel,138000.0,2020
+118 000,Mercedes-Benz CLA Importée Tn245,Diesel,138000.0,2020
+149 000,Mercedes-Benz CLA,Essence,87000.0,2021
+110 000,Volkswagen Golf 8 STYLE 1.5 BVA eTSI  importée,Essence,87000.0,2021
+98 000,KIA Sportage GT-Line,Diesel,119000.0,2019
+99 000,Haval H6,Essence,16000.0,2022
+185 000,BMW Série 5 Pack M,Essence,70000.0,2021
+107 000,BMW Série 4 Gran Coupé,Essence,53000.0,2020
+30 000,Hyundai Grand i10 Sedan,Essence,150000.0,2017
+135 000,Mercedes-Benz Classe C AMG +,Essence,146000.0,2015
+95 000,Volkswagen Golf 8 Active,Essence,69000.0,2021
+420 000,Mercedes-Benz GLE Coupé,Diesel,54000.0,2020
+115 000,Mazda CX-5 High Grade,Essence,63000.0,2019
+65 000,MG ZS,Essence,65000.0,2019
+70 000,Seat Leon,Essence,61847.0,2020
+97 000,Mercedes-Benz CLA Urban,Essence,125043.0,2018
+150 000,KIA Sportage Hybride GT-Line,Hybride,36000.0,2023
+54 000,KIA Rio 5p SX,Essence,68954.0,2019
+75 000,Volkswagen Golf 7 Highline,Essence,26043.0,2016
+87 000,Volkswagen Golf 8 Life,Essence,70001.0,2020
+175 000,Toyota Land Cruiser,Diesel,142060.0,2010
+69 000,Volkswagen Golf 7 Confortline,Essence,169452.0,2019
+40 000,BMW Série 1,Essence,131766.0,2009
+165 000,Mercedes-Benz Classe E AMG,Essence,55001.0,2019
+275 000,Mercedes-Benz Classe C AMG +,Essence,0.0,2024
+235 000,Mercedes-Benz GLA La nouvelle Gla 250e AMG,Hybride,10730.0,2023
+390 000,Mercedes-Benz Classe E AMG,Essence,10776.0,2023
+65 000,BMW X3 Luxury Line,Diesel,186000.0,2006
+185 000,Mercedes-Benz Classe C AMG,Essence,50893.0,2022
+43 000,KIA Picanto Populaire,Essence,3805.0,2021
+36 000,Lada 4x4 Urban,Essence,24387.0,2018
+126 000,Haval H6,Essence,12442.0,2023
+51 000,Nissan Juke Tekna,Essence,163166.0,2014
+160 000,Mitsubishi Pajero LIMITED EDITION,Diesel,20742.0,2023
+169 900,Mercedes-Benz CLA AMG Edition 1,Hybride,31235.0,2021
+64 000,Peugeot 308 GT-Line GT-Line,Diesel,96300.0,2020
+129 000,Toyota Prado,Diesel,199425.0,2003
+135 000,Mini 5 portes,Essence,18000.0,2021
+62 000,BMW Série 3 coupé,Essence,156000.0,2010
+30 000,Mahindra KUV 100 K6+,Essence,63000.0,2021
+93 000,Haval Jolion 1 ere,Essence,30000.0,2023
+126 000,Peugeot 308,Diesel,48000.0,2023
+198 000,Volkswagen Tiguan R-Line,Essence,54723.0,2023
+59 000,Peugeot Expert,Diesel,139199.0,2019
+138 000,Volkswagen Golf 8 R-Line,Hybride,36651.0,2022
+48 000,Mini Cabrio,Essence,86111.0,2010
+61 000,KIA Picanto 1 ère main,Essence,0.0,2024
+275 000,Porsche Cayman S,Essence,39508.0,2008
+54 000,Seat Ibiza,Essence,99519.0,2021
+119 000,Toyota Land Cruiser,Diesel,316620.0,2003
+230 000,Mercedes-Benz GLC Coupé AMG,Hybride,82415.0,2020
+65 000,Mercedes-Benz Classe C AMG,Essence,249000.0,2011
+178 000,Mercedes-Benz Classe C,Essence,30570.0,2021
+71 000,Peugeot 3008,Essence,105000.0,2017
+225 000,Mercedes-Benz CLA AMG,Hybride,1000.0,2024
+88 000,Volkswagen Golf 8,Essence,85181.0,2020
+79 000,Volkswagen Golf 7 Join,Essence,86000.0,2018
+78 000,Volkswagen T-roc,Essence,74107.0,2019
+36 000,Renault Symbol,Essence,115000.0,2020
+185 000,Mercedes-Benz CLA AMG,Hybride,18500.0,2023
+135 000,Mercedes-Benz Classe A AMG,Essence,68000.0,2018
+65 000,BMW Série 3 Luxury,Essence,112000.0,2013
+110 000,Audi Q5 S-line,Diesel,176000.0,2015
+145 000,Mercedes-Benz Classe C AMG,Diesel,145000.0,2019
+50 000,Peugeot 2008 Allure Toit Cielo Blanc Nacré,Essence,125000.0,2018
+119 000,Mercedes-Benz Classe A AMG,Diesel,141000.0,2019
+145 000,Volkswagen Golf 8 GTE,Hybride,26000.0,2021
+220 000,Mercedes-Benz CLA AMG,Hybride,6000.0,2024
+78 000,Mercedes-Benz Classe A AMG Premium,Essence,131000.0,2013
+46 500,KIA Picanto,Essence,28000.0,2021
+48 000,Ford Fusion Titanium,Essence,217000.0,2016
+49 800,Mini 5 portes Très bon état,Essence,160000.0,2016
+45 000,BMW Série 3,Essence,180000.0,2012
+60 000,Seat Leon 1.2L,Essence,140000.0,2018
+200 000,Land Rover Range Rover Sport,Essence,190000.0,2015
+89 000,Peugeot 3008 1.2L,Essence,70000.0,2020
+87 000,Volkswagen Golf 8,Essence,58000.0,2022
+89 000,KIA Sportage 1.6L Diesel,Diesel,105000.0,2018
+55 500,Mercedes-Benz Classe C,Essence,235000.0,2013
+47 000,Audi Q5 2.0L,Essence,255000.0,2009
+139 000,Volkswagen Golf 8,Essence,40000.0,2023
+89 000,Mercedes-Benz Classe C AMG,Essence,164000.0,2014
+138 000,Mercedes-Benz Classe E 1.6L,Essence,132000.0,2017
+108 000,Seat Leon Xcellence,Essence,37000.0,2023
+72 000,Jeep Wrangler 4.0L,Essence,200000.0,1989
+38 500,Renault Clio 1.0L,Essence,135000.0,2021
+78 500,Audi A3 Sportback 1.2L,Essence,125000.0,2019
+119 000,Cupra Formentor 1.5L,Hybride,19000.0,2022
+55 500,Ford Fusion 1.6,Essence,90000.0,2017
+49 500,Mazda 3,Essence,124000.0,2017
+39 500,Nissan Juke,Essence,160000.0,2015
+227 000,Volvo XC60 2.0L,Essence,18000.0,2022
+39 800,Hyundai Grand i10 1.0L,Essence,57000.0,2021
+43 000,Skoda Fabia 1.6L,Essence,137000.0,2018
+75 000,BMW Série 5 520,Essence,182000.0,2014
+93 000,Volkswagen Golf 8 1.5L,Essence,80000.0,2021
+132 000,BMW X2 S drive,Essence,74000.0,2020
+73 500,Volkswagen Golf 7 Importé,Essence,40000.0,2020
+85 000,BMW X1 1.6L,Essence,126000.0,2016
+138 500,BMW Série 1 M,Essence,40000.0,2022
+58 500,Citroën Berlingo Utilitaire 1.6L,Diesel,31000.0,2023
+38 000,Citroën C3,Essence,92000.0,2018
+34 500,Citroën C3 Live,Essence,119000.0,2019
+38 000,Citroën C4,Essence,109000.0,2012
+88 000,Peugeot 3008 Allure,Essence,38000.0,2019
+159 000,Mercedes-Benz Classe C Avantgarde,Essence,27000.0,2022
+75 000,Peugeot 3008 Allure,Essence,75000.0,2020
+139 000,BMW X4,Diesel,140000.0,2018
+65 500,Volkswagen Polo R-Line,Essence,70000.0,2020
+69 000,Volkswagen Golf 7 BVA,Essence,200000.0,2020
+75 000,BMW Série 1 Pack Sport M,Essence,165000.0,2016
+147 000,Hyundai Tucson Top Grade,Essence,40000.0,2022
+41 000,Lada 4x4 Urban,Essence,58000.0,2020
+205 000,Mercedes-Benz Classe X,Diesel,68000.0,2020
+81 000,Seat Arona Xperience,Essence,47000.0,2022
+69 000,Toyota Corolla Dynamic,Essence,85000.0,2020
+65 000,Fiat 500X Pop Star,Essence,60000.0,2018
+115 000,Land Rover Discovery,Essence,170000.0,2015
+88 000,Haval Jolion,Essence,40000.0,2021
+73 000,Toyota C-HR,Essence,130000.0,2018
+92 500,Nissan Juke Tekna,Essence,6000.0,2024
+Sous leasing                    255 100,Mercedes-Benz Classe C AMG,Essence,20000.0,2023
+129 000,Mercedes-Benz CLA Kit Amg 200,Essence,150000.0,2020
+62 000,Seat Ibiza Xcellence,Essence,68000.0,2021
+57 500,KIA Rio 5p SX,Essence,70000.0,2020
+72 000,MG ZS Luxury,Essence,20000.0,2022
+101 000,Chery Tiggo 7 Pro,Essence,0.0,2024
+165 000,Audi Q3 BVA,Essence,3000.0,2023
+155 000,Peugeot 408 GT,Essence,10000.0,2024
+87 000,Jaguar XF Luxury,Essence,120000.0,2014
+85 000,BMW Série 6 Face Lift,Essence,190000.0,2009
+189 000,Land Rover Range Rover Sport HSE Dynamic,Diesel,300000.0,2016
+62 000,KIA Rio 5p GT-Line,Essence,70000.0,2021
+188 000,KIA Sportage GT-Line,Hybride,15000.0,2024
+225 000,Mercedes-Benz GLA 250e Pack AMG,Hybride,26000.0,2023
+39 000,Mahindra Pick-up SC,Diesel,120000.0,2021
+69 000,Peugeot 3008,Essence,112000.0,2020
+73 000,KIA Rio 5p GT-Line,Essence,9000.0,2023
+152 000,Mercedes-Benz Classe C Pack AMG Pack night,Hybride,120000.0,2019
+89 000,Peugeot 3008 GT GT-line,Essence,125000.0,2020
+77 900,MG HS Luxury,Essence,87000.0,2020
+173 000,Mercedes-Benz GLA AMG,Essence,90000.0,2021
+87 000,BMW Série 4 Coupé 420i,Essence,180000.0,2015
+88 000,Chery Tiggo 7 Pro,Essence,40000.0,2022
+98 000,Suzuki Jimny,Essence,20000.0,2023
+83 000,Mercedes-Benz CLA Kit AMG,Essence,124000.0,2014
+37 500,Citroën C3 Shine,Essence,88000.0,2018
+63 000,Mercedes-Benz Classe C coupé AMG,Essence,200000.0,2012
+45 000,Renault Clio 4,Essence,120000.0,2021
+29 000,Mini 3 portes One,Essence,200000.0,2009
+129 000,Hyundai Tucson High Grade,Essence,19000.0,2023
+87 000,Nissan Juke Tekna,Essence,53000.0,2021
+88 000,Jeep Renegade,Essence,88000.0,2021
+152 000,Mercedes-Benz Classe C AMG,Hybride,120000.0,2019
+109 000,Ford Mondeo Hybride,Hybride,34000.0,2020
+120 000,Land Rover Range Rover Evoque,Diesel,145000.0,2018
+59 000,Volkswagen Passat,Essence,160000.0,2016
+117 000,Haval H6,Essence,16000.0,2022
+85 000,Haval H6 Luxury,Essence,55000.0,2021
+105 000,Volkswagen Golf 8 1.4,Essence,40000.0,2022
+179 000,Jaguar F-Pace R_Dynamic,Diesel,165000.0,2017
+70 000,Renault Kadjar,Essence,140000.0,2018
+79 000,Toyota Corolla,Essence,24000.0,2022
+47 000,Peugeot 308,Essence,128000.0,2020
+167 000,Mercedes-Benz Classe C coupé AMG,Essence,130000.0,2018
+47 500,Citroën C3 Shine,Essence,45000.0,2020
+40 000,Ford Focus Titanium,Essence,200000.0,2015
+178 000,Porsche Panamera,Essence,82000.0,2011
+89 000,KIA Seltos,Essence,130000.0,2021
+81 000,Seat Ibiza FR,Essence,40000.0,2023
+77 000,Alfa Romeo Giulietta,Essence,37000.0,2019
+235 000,Land Rover Discovery R-DYNAMIC,Diesel,87000.0,2020
+49 000,Volkswagen Golf 7 Confortline,Essence,190000.0,2013
+64 500,Renault Megane 4 Diesel,Diesel,125000.0,2020
+65 000,KIA Rio 5p GT-Line,Essence,60000.0,2021
+35 000,Fiat Fiorino,Diesel,120000.0,2021
+75 000,Dacia Duster Techroad,Essence,35000.0,2020
+278 000,BMW Série 5 530e Xdrive Pack m,Hybride,50000.0,2021
+97 000,BMW Série 4 Gran Coupé 418 Luxury,Essence,133000.0,2016
+125 000,Volkswagen Passat R-Line DSG,Essence,40000.0,2022
+290 000,Toyota Hilux Double Cabine Gr Sport,Diesel,7000.0,2024
+91 000,Toyota C-HR,Essence,55000.0,2022
+109 000,Audi A5 Sportback S-Line,Essence,120000.0,2019
+80 000,Peugeot 2008,Diesel,100000.0,2021
+Sous leasing                    59 700,KIA Rio 5p,Essence,85000.0,2022
+91 000,Honda CR-V,Essence,67000.0,2018
+295 000,Audi Q5 S-line,Diesel,40000.0,2021
+107 000,KIA Sportage Hybride,Hybride,114000.0,2021
+128 000,KIA Sportage GT-Line,Diesel,19000.0,2021
+76 000,Dacia Duster Techroad,Essence,34000.0,2020
+660 000,Mercedes-Benz Classe S AMG,Hybride,3000.0,2022
+455 000,BMW X5 Hybride Xdrive E45,Hybride,19000.0,2021
+138 000,Hyundai Tucson Hybride Xcellence,Hybride,120000.0,2022
+75 000,BMW Série 1 I Pack Sport,Essence,200000.0,2019
+105 000,KIA Sportage GT-Line,Diesel,140000.0,2017
+235 000,Mercedes-Benz Classe C AMG,Essence,50000.0,2023
+120 000,Jaguar XE,Diesel,140000.0,2017
+72 000,Peugeot Rifter,Diesel,95000.0,2020
+110 000,BMW Série 7 740LI,Essence,98000.0,2010
+72 000,Peugeot Rifter 5 places,Diesel,95000.0,2020
+187 000,Land Rover Range Rover Evoque Hybride,Diesel,50000.0,2019
+115 000,Ford Mondeo Hybride,Hybride,32000.0,2020
+64 000,KIA Rio 5p GT-Line,Essence,64000.0,2021
+169 000,Mercedes-Benz GLC AMG,Essence,115000.0,2017
+57 000,Mini 5 portes One,Essence,78000.0,2016
+48 000,Citroën C3 Shine,Essence,28000.0,2020
+85 000,Audi A3 Berline,Essence,50000.0,2019
+83 500,KIA Sportage,Essence,127000.0,2019
+Non dédouané                    235 000,Mercedes-Benz GLA AMG,Essence,12000.0,2023
+95 000,Audi Q3,Essence,95000.0,2017
+210 000,Mercedes-Benz GLB 200 d,Diesel,111000.0,2021
+58 000,Audi A4 Face_lift,Essence,143000.0,2016
+95 000,Land Rover Range Rover Evoque Face_lift,Essence,170000.0,2016
+135 000,BMW Série 1 Pack M,Essence,40000.0,2020
+195 000,Land Rover Range Rover Evoque Hybride,Diesel,40000.0,2019
+79 000,Haval H6 Luxury,Essence,120000.0,2020
+105 000,Iveco Daily Simple Cabine,Diesel,40000.0,2022
+128 000,Land Rover Discovery Sport,Diesel,128000.0,2017
+90 000,Haval H6 Luxury,Essence,40000.0,2021
+98 000,KIA Sportage Hybride,Hybride,140000.0,2020
+85 000,KIA Sportage,Essence,125000.0,2019
+137 000,Hyundai Tucson Hybride,Hybride,80000.0,2021
+165 000,Audi Q5 QUATTRO 40 TDI,Diesel,170000.0,2019
+43 500,Fiat Panda City Cross,Essence,52000.0,2020
+45 000,Volkswagen Golf 6 Match,Diesel,240000.0,2012
+228 000,Ford Ranger Raptor,Diesel,100000.0,2022
+130 000,BMW Série 4 Coupé Pack M,Essence,140000.0,2021
+48 000,Mercedes-Benz Classe B,Essence,100000.0,2014
+75 000,MG ZS Luxury,Essence,80000.0,2022
+210 000,Land Rover Range Rover Evoque Hybride,Diesel,60000.0,2019
+68 000,Renault Kadjar,Essence,70000.0,2019
+56 000,Mazda 3 Sky active,Essence,103000.0,2017
+398 000,Audi Q8 S_Line,Essence,16000.0,2021
+173 000,Mercedes-Benz Classe C coupé AMG,Essence,50000.0,2019
+Sous leasing                    78 000,MG ZS,Essence,35000.0,2022
+40 000,Suzuki Baleno,Essence,160000.0,2017
+95 000,KIA Sportage,Essence,69000.0,2019
+69 000,Ford Kuga,Essence,100000.0,2017
+119 000,Mercedes-Benz CLS AMG,Diesel,160000.0,2011
+185 000,Mercedes-Benz GLA 180 Pack AMG,Essence,40000.0,2022
+73 500,Seat Arona,Essence,26000.0,2021
+71 000,Toyota Corolla,Essence,90000.0,2021
+79 000,Haval H6 Luxury,Essence,115000.0,2020
+125 000,Skoda Superb Ambassador,Essence,30000.0,2021
+79 000,MG 6,Essence,22000.0,2021
+189 000,Mercedes-Benz GLC Coupé AMG,Diesel,190000.0,2017
+89 000,Mercedes-Benz Classe C 180 elegance,Essence,170000.0,2016
+278 000,Mercedes-Benz GLC Coupé AMG,Hybride,69000.0,2020
+135 000,Mercedes-Benz Classe E 180,Essence,90000.0,2018
+42 000,Ssangyong Actyon Sports,Diesel,200000.0,2017
+35 000,DS 3,Essence,138000.0,2012
+97 000,Audi A3 Berline,Essence,17000.0,2020
+43 000,Nissan Qashqai,Essence,147000.0,2011
+90 000,BMW Série 5 Confort Luxury,Essence,200000.0,2015
+101 000,Volkswagen Passat R-Line,Essence,100000.0,2019
+125 000,Land Rover Discovery Sport,Diesel,160000.0,2017
+44 500,Citroën C3 Shine,Essence,90000.0,2019
+49 000,Volkswagen Amarok,Diesel,370000.0,2012
+Sous leasing                    291 800,Mercedes-Benz Classe E Business,Essence,8000.0,2022
+37 000,Mini 3 portes one,Essence,140000.0,2013
+68 000,BMW Série 1,Essence,126000.0,2017
+231 000,Toyota Hilux Double Cabine 4*4,Essence,3000.0,2024
+97 000,Peugeot 2008 Allure,Essence,34000.0,2022
+158 000,Mercedes-Benz Classe A AMG,Essence,20000.0,2022
+106 000,Volkswagen Passat R-Line,Essence,60000.0,2020
+90 000,Volkswagen Tiguan,Essence,60000.0,2018
+99 000,Mercedes-Benz Classe C AMG,Essence,160000.0,2014
+96 000,Chery Tiggo 8 Pro,Essence,80000.0,2022
+47 000,BYD F3,Essence,10000.0,2022
+44 500,Citroën C3 Shine,Essence,58000.0,2019
+107 000,BMW Série 4 Coupé 420i Pack M,Essence,160000.0,2015
+90 000,Audi Q3 S-line,Essence,100000.0,2017
+109 000,Volkswagen Golf 8 United,Essence,26000.0,2020
+35 000,Peugeot 208,Essence,60000.0,2020
+59 000,Audi A5 Cabriolet S-line,Essence,120000.0,2010
+135 000,Honda Accord,Essence,11000.0,2022
+74 000,Volkswagen Golf 7,Essence,40000.0,2019
+119 000,KIA Sportage,Essence,40000.0,2020
+135 000,BMW Série 2 Gran Coupé 218i,Essence,21000.0,2022
+46 000,Fiat Tipo 5 portes,Essence,75000.0,2018
+Sous leasing                    150 600,Haval H6,Essence,13000.0,2022
+52 000,Volkswagen Golf 7 Smartline,Essence,140000.0,2015
+78 000,Haval H6 Luxury,Essence,90000.0,2019
+40 000,Chevrolet Cruze,Essence,90000.0,2018
+76 000,Volkswagen Golf 7,Essence,29000.0,2019
+51 000,Mercedes-Benz Classe E 200,Essence,330000.0,2010
+77 000,Mercedes-Benz Classe E e220,Diesel,330000.0,2011
+145 000,Volkswagen Golf 8 R-Line,Essence,40000.0,2021
+240 000,Mercedes-Benz Classe C AMG,Essence,16000.0,2023
+Non dédouané                    212 000,Dodge RAM Rumble bee,Essence,65000.0,2019
+81 000,Mercedes-Benz CLA,Essence,163000.0,2014
+69 000,Haval H2 Luxury,Essence,40000.0,2019
+86 000,Haval H6 Luxury,Essence,32000.0,2019
+169 000,Mercedes-Benz CLA AMG,Essence,30000.0,2021
+98 000,Mercedes-Benz Classe A 180d,Diesel,50000.0,2019
+74 000,Volkswagen Golf 7,Essence,64000.0,2019
+95 000,Audi A3 Sportback S-Line,Essence,70000.0,2019
+205 000,Mercedes-Benz Classe C AMG,Essence,40000.0,2022
+105 000,DS 7 Crossback Grand Chic,Essence,140000.0,2021
+Sous leasing                    264 200,Mercedes-Benz Classe C AMG,Essence,50000.0,2022
+84 000,Volkswagen Golf 7 Join,Essence,70000.0,2018
+79 000,Mercedes-Benz CLA 220,Diesel,240000.0,2013
+110 000,BMW X6 Pack M,Diesel,270000.0,2008
+59 000,Audi A5 Cabriolet S-line,Essence,120000.0,2010
+73 000,Seat Leon Style,Essence,65000.0,2020
+37 500,Citroën Berlingo Utilitaire,Diesel,170000.0,2018
+143 000,KIA Sportage,Essence,23000.0,2022
+64 000,Volkswagen Golf 7,Essence,180000.0,2019
+78 000,Mercedes-Benz Classe S Executive,Essence,170000.0,2008
+128 000,Volkswagen Tiguan Confortline,Essence,33000.0,2020
+80 000,Volkswagen Golf 7 R-Line,Essence,130000.0,2018
+79 000,Hyundai Kona,Hybride,30000.0,2021
+Sous leasing                    122 800,Seat Leon FR,Essence,70000.0,2022
+53 000,Hyundai Grand i10,Essence,30000.0,2022
+92 000,Peugeot 2008 GT_LINE,Essence,30000.0,2021
+179 000,Mercedes-Benz Classe C coupé AMG,Essence,40000.0,2019
+119 000,KIA Sportage GT-Line,Hybride,120000.0,2021
+88 000,BMW Série 3 318i,Essence,117000.0,2017
+43 500,Chery Tiggo 2 Confort,Essence,60000.0,2020
+87 000,Haval Jolion,Essence,40000.0,2022
+208 000,Mercedes-Benz Classe C AMG,Essence,40000.0,2022
+53 000,Hyundai Grand i10,Essence,54000.0,2021
+68 000,Seat Ibiza FR,Essence,100000.0,2020
+169 000,Mercedes-Benz CLA AMG,Essence,20000.0,2020
+67 000,Seat Ibiza FR,Essence,50000.0,2020
+85 000,Volkswagen T-roc,Essence,87000.0,2020
+113 000,Mercedes-Benz GLA AMG,Essence,74000.0,2016
+115 000,Mercedes-Benz Classe C AMG,Essence,170000.0,2014
+188 000,Audi Q3 Sportback,Essence,10000.0,2021
+215 000,Audi Q5,Diesel,100000.0,2018
+125 000,Volkswagen Golf 8 R-Line,Essence,70000.0,2021
+185 000,Jaguar F-Pace R-DYNAMIC,Diesel,165000.0,2017
+77 000,Peugeot 3008 GT-line,Essence,260000.0,2017
+Non dédouané                    350 000,Land Rover Range Rover Velar R-Dynamic,Diesel,100000.0,2019
+255 000,Porsche Panamera PLATINUM édition,Essence,100000.0,2014
+295 000,Land Rover Range Rover Velar R-Dynamic,Essence,90000.0,2020
+Sous leasing                    182 900,Dongfeng Forthing T5 EVO,Essence,4000.0,2023
+47 000,Chery Tiggo 3,Essence,75000.0,2018
+85 000,Audi Q3,Essence,77000.0,2017
+66 000,Renault Kadjar Intens,Essence,150000.0,2018
+155 000,Volkswagen Golf 8 R-Line,Essence,40000.0,2021
+205 000,Mercedes-Benz Classe C AMG,Hybride,35000.0,2020
+80 000,Volkswagen Golf 7 Join,Essence,120000.0,2019
+99 000,BMW Série 4 Gran Coupé Luxury,Essence,100000.0,2018
+161 000,Hyundai Tucson,Essence,24000.0,2023
+87 000,Hyundai Tucson,Essence,120000.0,2020
+92 000,BMW Série 1 Pack sport,Essence,70000.0,2020
+45 000,Fiat Panda City Cross,Essence,20000.0,2022
+125 000,BMW Série 4 Gran Coupé 418 PACK M,Essence,110000.0,2017
+77 000,Mercedes-Benz Classe E AMG,Essence,135000.0,2011
+215 000,Mercedes-Benz Classe C AMG,Essence,80000.0,2022
+65 000,Dongfeng SX3,Essence,30000.0,2021
+128 000,Volkswagen Golf 8 United,Essence,16000.0,2021
+172 000,Mercedes-Benz Classe A AMG,Essence,15000.0,2022
+148 000,Mercedes-Benz Classe C AMG,Diesel,80000.0,2019
+62 000,MG GS Luxe,Essence,115000.0,2017
+Sous leasing                    122 800,Mitsubishi ASX 4WD,Essence,55000.0,2021
+126 000,Land Rover Discovery,Diesel,130000.0,2017
+185 000,Audi A5 Sportback,Essence,70000.0,2021
+45 000,BMW Série 7 Individuel,Essence,300000.0,2008
+245 000,Land Rover Range Rover Sport,Diesel,160000.0,2014
+110 000,BMW Série 4 Coupé,Essence,78000.0,2017
+61 000,MG GS Luxe Plus,Essence,100000.0,2017
+40 000,Peugeot RCZ,Essence,171000.0,2011
+118 000,Land Rover Discovery Sport,Diesel,94000.0,2016
+87 000,Volkswagen Amarok AWD,Diesel,180000.0,2016
+55 000,BMW Série 7 740I FACE-LIFT,Essence,220000.0,2008
+69 000,Ford Ecosport Titanium,Essence,67000.0,2022
+120 000,Toyota Corolla Cross Hybride High,Hybride,36000.0,2022
+58 000,MG ZS Confort Plus,Essence,141000.0,2019
+85 000,KIA Sportage,Essence,150000.0,2019
+74 000,BMW Série 3 coupé Kit M///,Essence,152000.0,2012
+71 000,Mercedes-Benz Classe C AMG,Essence,200000.0,2011
+75 000,Audi A5 Coupé,Essence,109000.0,2014
+58 500,KIA Rio 5p SX,Essence,35000.0,2020
+36 500,BMW Série 1 Business Line,Essence,251000.0,2012
+78 000,Volkswagen Golf 7 Sound,Essence,125000.0,2018
+170 000,Mercedes-Benz CLA AMG,Hybride,25000.0,2021
+135 000,Mercedes-Benz Classe A AMG,Hybride,35000.0,2020
+50 000,Peugeot 308,Essence,102000.0,2020
+67 000,Ford Ecosport Titanium,Essence,44000.0,2022
+62 000,Fiat 500 Cult Club,Essence,3000.0,2023
+115 000,Mercedes-Benz Classe A AMG,Essence,60000.0,2021
+110 000,Volkswagen Tiguan R-Line,Essence,160000.0,2019
+40 000,Volkswagen Scirocco,Essence,200000.0,2010
+115 000,Audi A5 Sportback,Essence,80000.0,2019
+100 000,Hyundai Tucson,Diesel,81000.0,2018
+125 000,Land Rover Discovery,Essence,110000.0,2016
+110 000,Mercedes-Benz Classe A,Essence,90000.0,2021
+178 000,Hyundai Tucson Hybride Top Grade,Diesel,16000.0,2023
+51 000,Peugeot 508,Essence,145000.0,2018
+145 000,Mercedes-Benz Classe C coupé AMG,Essence,120000.0,2019
+230 000,Land Rover Range Rover Sport,Diesel,90000.0,2017
+220 000,Porsche Cayenne,Essence,158000.0,2015
+67 000,BMW Série 3,Essence,210000.0,2015
+108 000,Mercedes-Benz Classe A,Essence,50000.0,2020
+66 000,Mercedes-Benz Classe C,Essence,180000.0,2013
+83 000,Renault Kadjar,Essence,98000.0,2021
+85 000,Land Rover Range Rover Sport,Diesel,208000.0,2007
+200 000,Audi Q3,Hybride,40000.0,2023
+95 000,KIA Sorento,Diesel,120000.0,2016
+118 000,KIA Sportage,Diesel,140000.0,2018
+53 000,KIA Rio 5p SX PLUS,Essence,99000.0,2020
+Sous leasing                    47 100,Wallyscar 719,Essence,86573.0,2023
+61 000,Renault Megane Sedan,Essence,46000.0,2019
+78 000,Ford Ecosport,Essence,19000.0,2022
+58 000,Mercedes-Benz ML,Diesel,250000.0,2007
+36 000,Ford Focus Trend Sport,Essence,180000.0,2014
+65 000,Toyota Prado Adventure,Diesel,330000.0,1999
+27 500,Peugeot 207 Access Plus,Diesel,290000.0,2011
+145 000,Mercedes-Benz CLA,Diesel,60000.0,2021
+63 500,Hyundai ix35 Toit Panoramique,Diesel,160000.0,2016
+41 300,Volkswagen Polo Sedan Trendline,Essence,170000.0,2020
+68 500,Mercedes-Benz Classe A AMG,Essence,180000.0,2014
+420 000,Mercedes-Benz GLC Coupé AMG,Essence,0.0,2024
+105 000,Mercedes-Benz Classe C,Essence,200000.0,2014
+65 000,Ssangyong Tivoli Confort Plus,Essence,4700.0,2018
+63 000,Mini 3 portes John Cooper Works,Essence,100000.0,2017
+168 000,Toyota Hilux Double Cabine D4D,Diesel,140000.0,2020
+255 000,Land Rover Range Rover Evoque HSE,Hybride,60000.0,2022
+132 000,Mercedes-Benz Classe A Berline AMG,Essence,100000.0,2020
+385 000,Land Rover Range Rover Sport Autobiography,Hybride,60000.0,2021
+220 000,Mercedes-Benz CLA AMG,Essence,0.0,2024
+480 000,Porsche Cayenne Coupé GTS,Hybride,70000.0,2020
+450 000,Mercedes-Benz GLE Coupé,Hybride,30000.0,2022
+260 000,Mercedes-Benz Classe E AMG,Hybride,70000.0,2020
+270 000,Mercedes-Benz GLC Coupé AMG,Hybride,80000.0,2021
+145 000,BMW Série 4 Gran Coupé KIT-M-individual,Essence,120000.0,2016
+115 000,Mercedes-Benz CLA,Diesel,130000.0,2017
+145 000,Audi A3 Sportback 1.5,Hybride,900.0,2023
+190 000,Tesla Model 3 Modèle 3 Highland 2024,Electrique,15000.0,2023
+197 000,Mercedes-Benz GLC AMG,Hybride,130000.0,2018
+168 000,Mercedes-Benz Classe E,Diesel,158000.0,2020
+56 000,Nissan Qashqai,Diesel,147000.0,2016
+145 000,Hyundai Tucson,Essence,37000.0,2022
+95 000,Audi Q2 Design,Essence,77000.0,2019
+62 000,KIA Rio 5p,Essence,51000.0,2021
+85 000,Toyota C-HR,Essence,71000.0,2021
+78 000,KIA Sportage Black Edition,Essence,117000.0,2018
+26 000,Mahindra KUV 100 K6+,Essence,90000.0,2021
+75 000,Toyota C-HR,Essence,165000.0,2020
+28 000,Ford Fiesta Trend,Essence,161000.0,2013
+150 000,BMW Série 4 Coupé M,Essence,85000.0,2019
+60 000,Renault Megane Sedan,Essence,70000.0,2021
+104 000,Mazda CX-9 High grade,Essence,155000.0,2019
+29 500,Ford Fiesta Titanium,Essence,223000.0,2013
+26 000,Peugeot Partner,Diesel,320000.0,2009
+37 900,Suzuki Celerio,Essence,45000.0,2022
+144 900,Mercedes-Benz CLA AMG,Essence,100000.0,2020
+90 000,MG HS Trophy,Essence,111000.0,2022
+41 500,Seat Ibiza,Essence,83000.0,2019
+48 000,Ssangyong Tivoli,Essence,235000.0,2018
+32 500,Mahindra KUV 100 K6+,Essence,59000.0,2022
+18 000,Hyundai H-1,Essence,999999.0,2006
+"29,500 DT",Nissan Micra,Essence,130000.0,2017
+"28,600 DT",BMW Serie 1,Essence,240000.0,2007
+0 DT,Suzuki Swift,Essence,91000.0,2021
+0 DT,Skoda Fabia,Essence,78000.0,2021
+0 DT,Kia Optima,Essence,247000.0,2014
+"25,800 DT",Fiat Doblo,Diesel,160000.0,2020
+"78,000 DT",Mercedes-Benz Classe C,Essence,207600.0,2014
+"39,500 DT",Kia Cerato,Essence,14400.0,2015
+"55,500 DT",Kia Rio,Essence,90000.0,2021
+0 DT,Citroen Berlingo,Diesel,181000.0,2019
+0 DT,Renault Megane,Diesel,149000.0,2020
+"44,500 DT",Volkswagen Polo,Essence,140000.0,2021
+"30,500 DT",Renault Clio,Essence,116000.0,2012
+950 DT,Citroen C5,Essence,250.0,2024
+0 DT,Chevrolet S-10,Essence,64000.0,2021
+0 DT,Renault Clio,Essence,67000.0,2021
+"17,500 DT",Peugeot 207,Essence,229999.0,2012
+0 DT,Mercedes-Benz Classe A,Essence,48000.0,2019
+"20,000 DT",Citroen Nemo,Diesel,420000.0,2014
+"13,500 DT",Peugeot 306,Essence,202000.0,2000
+0 DT,Fiat Tipo,Diesel,113167.0,2020
+"34,000 DT",Citroen C3,Essence,97000.0,2018
+"29,000 DT",SsangYong Actyon,Diesel,424000.0,2015
+0 DT,Volkswagen Polo,Essence,84200.0,2021
+0 DT,Suzuki Celerio,Essence,58000.0,2021
+"9,000 DT",Opel Corsa,Essence,312.0,N.C
+"1,111 DT",Volkswagen Golf 5,Essence,170000.0,2007
+"66,500 DT",Peugeot 3008,Essence,100000.0,2019
+0 DT,Mercedes-Benz Classe A,N.C,32000.0,2021
+"78,000 DT",Peugeot Partner,Diesel,70000.0,2020
+0 DT,Kia Sportage,Diesel,139000.0,2018
+"41,500 DT",Skoda Fabia,Essence,130000.0,2021
+0 DT,Toyota Corolla,Essence,31000.0,2021
+0 DT,Mercedes-Benz Classe C,N.C,26000.0,2022
+0 DT,Haval H6,Essence,15000.0,2022
+0 DT,Renault Clio,Essence,95000.0,2020
+"105,000 DT",BMW Serie 4,Essence,150000.0,2019
+"152,000 DT",BMW X4,Essence,62000.0,2016
+0 DT,Mercedes-Benz Classe A,Essence,48000.0,2020
+0 DT,Volkswagen Golf,Essence,190000.0,2012
+0 DT,BMW Serie 5,Essence,140000.0,2017
+"53,000 DT",Fiat Tipo,Essence,113000.0,2020
+0 DT,Renault Clio,Diesel,,2021
+0 DT,Volkswagen Passat CC,Essence,111000.0,2019
+0 DT,Volkswagen Golf 8,Essence,38000.0,2021
+0 DT,Volkswagen Golf 7,Essence,81000.0,2018
+0 DT,Volkswagen Golf 7,Essence,71000.0,2019
+0 DT,Peugeot 208,Essence,65000.0,2020
+0 DT,Volkswagen Passat,N.C,50000.0,2020
+"48,500 DT",Renault Megane,Essence,150000.0,2020
+0 DT,Renault Clio,Essence,241000.0,2008
+"79,000 DT",Ford Focus,Essence,60000.0,2020
+"82,000 DT",Nissan Juke,Essence,27000.0,2023
+0 DT,Peugeot Partner,Diesel,119000.0,2021
+0 DT,Mitsubishi L200,Diesel,205000.0,2017
+"44,000 DT",Peugeot 2008,Essence,117000.0,2018
+"33,800 DT",Nissan Micra,Essence,74300.0,2020
+0 DT,SEAT Ibiza,Essence,,2014
+"67,000 DT",Mercedes-Benz Classe E,Essence,197000.0,2010
+"55,000 DT",Audi A6,Essence,166920.0,2016
+"41,000 DT",Hyundai i10,Essence,65000.0,2023
+0 DT,Volkswagen Golf 8,N.C,69000.0,2021
+0 DT,Alfa Romeo Giulietta,Essence,143000.0,2015
+0 DT,Volkswagen Passat,Essence,128000.0,2010
+"96,000 DT",Kia Sportage,Essence,45000.0,N.C
+0 DT,Fiat Linea,Essence,167000.0,2009
+"1,111 DT",Jeep Compass,Essence,64000.0,2020
+"1,111 DT",BMW Serie 4,Essence,150000.0,2019
+"1,111 DT",Land Rover Range Rover Sport,Hybride,42000.0,2020
+0 DT,Porsche Cayenne,Essence,10000.0,2015
+0 DT,Mercedes-Benz Classe A,Essence,89000.0,2020
+0 DT,Renault Captur,N.C,90000.0,2022
+"38,500 DT",Fiat Panda,Essence,130000.0,2022
+"42,000 DT",Ford Focus,Essence,120000.0,2016
+0 DT,Fiat Siena,Essence,200000.0,2006
+"75,000 DT",Kia Sportage,Essence,160000.0,2017
+"45,500 DT",Fiat 500C,Essence,71000.0,2017
+0 DT,Dacia Dokker,Diesel,127000.0,2021
+0 DT,Peugeot 308,Diesel,208000.0,2011
+0 DT,Hyundai Tucson,Essence,,2008
+0 DT,Volkswagen Golf,Diesel,182000.0,2012
+0 DT,Volkswagen Golf,Diesel,134000.0,2020
+"61,500 DT",Citroen DS5,Essence,110000.0,2017
+0 DT,Renault Clio,Essence,90000.0,2019
+"42,000 DT",Citroen C3,Essence,98270.0,2018
+0 DT,SEAT Ibiza,Essence,48000.0,2019
+"117,000 DT",Kia Sportage,N.C,54000.0,2020
+"58,000 DT",Volkswagen Passat,Essence,140000.0,2016
+"54,000 DT",Peugeot 2008,Essence,90000.0,2019
+"22,800 DT",Chery QQ,Essence,104000.0,2019
+"45,500 DT",Peugeot 208,Essence,78000.0,2021
+"78,000 DT",Audi A3,Essence,98000.0,2020
+"13,500 DT",Opel Corsa,Essence,266000.0,2000
+"70,000 DT",SEAT Leon,Essence,61847.0,2019
+0 DT,Mercedes-Benz Classe CLA,N.C,27000.0,2022
+"35,500 DT",Citroen C3,Essence,58000.0,2021
+"46,500 DT",Kia Picanto,Essence,28000.0,2021
+0 DT,Volkswagen Polo,Essence,81000.0,2022
+"90,000 DT",MG ZS,Essence,13.0,2024
+"47,000 DT",Nissan Navara,Diesel,315000.0,2012
+0 DT,Ford Fiesta,Essence,197000.0,2010
+0 DT,Toyota Aygo,Essence,60000.0,2017
+0 DT,Mercedes-Benz 220,Diesel,250000.0,2002
+0 DT,SEAT Ibiza,Essence,106000.0,2021
+0 DT,Volkswagen Golf,Essence,80000.0,2018
+0 DT,Kia Sportage,Diesel,24000.0,2017
+0 DT,Peugeot Partner,Diesel,105000.0,2020
+0 DT,Audi A3,Diesel,210000.0,2010
+"30,000 DT",Peugeot 508,Essence,268000.0,2012
+"40,500 DT",Renault Clio,Essence,110000.0,2016
+0 DT,Mercedes-Benz Classe A,Essence,68653.0,2018
+0 DT,BMW Serie 5,Diesel,287586.0,2007
+0 DT,Hyundai Grand i10,Essence,94260.0,2017
+0 DT,Kia Sportage,Diesel,207991.0,2018
+"19,500 DT",Renault Megane,Diesel,350000.0,2007
+0 DT,Peugeot 308,Essence,36799.0,2021
+"48,500 DT",Kia Rio,Essence,170000.0,2021
+"42,500 DT",Renault Clio,Essence,80000.0,2021
+0 DT,Toyota Hilux,Diesel,,2018
+0 DT,Kia Sportage,Essence,150000.0,2019
+0 DT,Renault Kadjar,Essence,60000.0,2023
+"8,500 DT",Renault Clio,Essence,300000.0,1993
+0 DT,Volkswagen Polo,Essence,189000.0,2012
+400 DT,Renault Clio,Essence,,2023
+0 DT,Citroen C3,Diesel,92000.0,2020
+0 DT,Mercedes-Benz Classe E,Essence,95000.0,2017
+0 DT,Fiat Doblo,Diesel,165000.0,2017
+"36,500 DT",Citroen C-Elysee,Essence,70000.0,2020
+0 DT,Renault Clio,Essence,150000.0,2006
+"52,000 DT",Volkswagen Polo,Essence,,2022
+"120,000 DT",Mazda BT-50,Essence,190000.0,2015
+0 DT,Audi A4,Essence,44000.0,2018
+"26,000 DT",Nissan Micra,Essence,160000.0,2013
+0 DT,Citroen Berlingo,Diesel,190000.0,2016
+0 DT,Peugeot Partner,Diesel,140000.0,2020
+"61,500 DT",Kia Rio,Essence,48000.0,2024
+"12,800 DT",Opel Corsa,Essence,350000.0,2000
+0 DT,Renault Clio,Essence,150000.0,2014
+0 DT,Suzuki Celerio,Essence,50000.0,2023
+0 DT,Volkswagen Polo,Essence,190000.0,2017
+0 DT,Mahindra Hover,Essence,2000.0,2024
+0 DT,Dacia Logan MCV,Essence,20000.0,2023
+0 DT,Renault Symbol,Essence,120000.0,2012
+"46,000 DT",Mazda CX-9,Essence,286000.0,2010
+0 DT,Volkswagen Golf,Diesel,203588.0,2012
+0 DT,Peugeot 208,Essence,112223.0,2017
+0 DT,Renault Symbol,Essence,195000.0,2011
+"41,000 DT",Renault Clio,Essence,91300.0,2020
+"61,000 DT",SsangYong Tivoli,Essence,74000.0,2020
+"77,500 DT",Mercedes-Benz Classe CLA,Essence,170000.0,2014
+"67,500 DT",BMW X5,Diesel,280000.0,2008
+"40,900 DT",Toyota Aygo,Essence,90000.0,2021
+"9,000 DT",Peugeot 205,Essence,111000.0,1993
+"27,500 DT",Peugeot 207,Diesel,290000.0,2011
+0 DT,BMW Serie 1,Essence,144000.0,2015
+0 DT,Kia Sportage,N.C,100000.0,2020
+0 DT,Volkswagen Polo,Essence,116000.0,2021
+0 DT,Hyundai Grand i10,Essence,90000.0,2021
+"1,000 DT",Renault R4,Essence,57000.0,1980
+"10,000 DT",Renault Clio,Essence,123000.0,2005
+"190,000 DT",Hyundai Santa Fe,Diesel,48000.0,2020
+0 DT,Mazda 6,Essence,157000.0,2018
+"19,000 DT",Peugeot 206,Essence,,2001
+"32,000 DT",Fiat Fiorino,Diesel,112000.0,2019
+0 DT,Citroen C3,Essence,81000.0,2021
+"173,000 DT",Mercedes-Benz Classe C,Essence,9000.0,2021
+0 DT,Volkswagen Golf,Essence,130000.0,2015
+"27,000 DT",Chevrolet Spark,Essence,121000.0,2015
+"35,000 DT",Peugeot 308,Essence,168000.0,2015
+"37,000 DT",SEAT Ibiza,Essence,205000.0,2020
+0 DT,Volkswagen Polo,Essence,80000.0,2021
+"51,500 DT",Hyundai i20,Essence,72000.0,2022
+"19,700 DT",Citroen C3,Essence,195540.0,2007
+"85,000 DT",Toyota C-HR,Essence,711000.0,2021
+"25,000 DT",Volkswagen Polo,Essence,47000.0,2006
+"33,000 DT",Hyundai i10,Essence,88000.0,2018
+0 DT,Mazda BT-50,Diesel,,2009
+"38,500 DT",Citroen Berlingo,Diesel,76470.0,2015
+0 DT,Peugeot 208,Essence,48000.0,2022
+"220,000 DT",Mercedes-Benz Classe A,Essence,10000.0,2002
+"64,000 DT",Volkswagen Caddy,Diesel,124000.0,2020
+"33,000 DT",Peugeot Partner,Diesel,282000.0,2016
+0 DT,Mercedes-Benz Classe B,Essence,226000.0,2009
+"65,000 DT",BMW X5,Essence,154000.0,2009
+"30,000 DT",Peugeot 208,Essence,113000.0,2017
+"56,000 DT",Volkswagen Passat,Diesel,300000.0,2013
+0 DT,Nissan Micra,Essence,190000.0,2018
+0 DT,Renault Megane,Diesel,2021.0,2021
+0 DT,Citroen Berlingo,Diesel,95000.0,2020
+0 DT,BMW Serie 1,Essence,185000.0,2016
+0 DT,Kia Picanto,Essence,30000.0,2022
+0 DT,Dacia Sandero,Essence,78000.0,2021
+0 DT,Peugeot 208,Essence,28000.0,2023
+"75,000 DT",Toyota C-HR,Essence,165000.0,2020
+0 DT,Suzuki Celerio,Essence,70000.0,2021
+"60,000 DT",Renault Megane,Essence,60000.0,2021
+"25,000 DT",Mercedes-Benz Classe A,Essence,100000.0,2002
+"8,000 DT",Peugeot 206,Diesel,,2003
+0 DT,Volkswagen Golf 8,Essence,60000.0,2021
+"22,000 DT",Peugeot 301,Essence,106000.0,2014
+"24,500 DT",Peugeot 301,Essence,170000.0,2015
+0 DT,Citroen Nemo,Diesel,232000.0,2018
+0 DT,Volkswagen Golf 4,Essence,298000.0,2000
+"42,500 DT",Suzuki Swift,Essence,49500.0,2019
+"42,300 DT",Kia Picanto,Essence,74000.0,2020
+0 DT,Renault Clio,Essence,231.0,N.C
+"40,000 DT",Kia Picanto,Essence,77000.0,2021
+0 DT,Mercedes-Benz Classe C,Essence,,2012
+0 DT,Audi Q5,Electrique,53000.0,2021
+0 DT,Dacia Duster,Essence,170000.0,2013
+0 DT,Hyundai i10,Essence,90.0,N.C
+"26,500 DT",Fiat Grande Punto,Essence,194500.0,2014
+"32,000 DT",Peugeot 308,Essence,180000.0,2015
+"43,000 DT",Renault Clio,Essence,105000.0,2020
+0 DT,Mercedes-Benz Classe C,Essence,,2010
+0 DT,Peugeot Partner,Diesel,90000.0,2012
+"24,800 DT",Renault Clio,Essence,200000.0,2010
+0 DT,Volkswagen Polo,Essence,186000.0,2011
+"42,500 DT",Volkswagen Polo,Essence,92500.0,2021
+"28,000 DT",Volkswagen Passat,Diesel,,2000
+0 DT,Skoda Fabia,Essence,82000.0,2021
+"15,500 DT",Chevrolet Aveo,Essence,258000.0,2005
+"15,500 DT",Renault Symbol,Essence,390000.0,2010
+0 DT,Volkswagen Polo,Diesel,200000.0,2001
+"175,000 DT",Volkswagen Golf 7,Essence,75000.0,2020
+"33,500 DT",BMW Serie 3,Essence,248000.0,2007
+0 DT,Hyundai i20,Essence,47000.0,2022
+"38,000 DT",Hyundai Accent,Essence,141000.0,2016

--- a/data/car_listings_baniola2.csv
+++ b/data/car_listings_baniola2.csv
@@ -1,0 +1,1001 @@
+Price (TND),Location,Title,Fuel Type,Year
+0 ,Bizerte,CHEVROLET SONIC PREMIÈRE MAIN EN ÉTAT NEUF,,
+33 800 ,Nabeul,Nissan Micra   1ère main,Essence,2020
+45 500 ,Beja,Great-wall MK-GT,Essence,2021
+32 000 ,Ben arous,Peugeot 308,Essence,2015
+61 ,Ben arous,Mazda MAZDA6,Essence,2018
+95 000 ,Tunis,Audi Q3,Essence,2019
+38 500 ,Bizerte,Volkswagen Golf 6,Diesel,2010
+22 000 ,Sousse,Peugeot 405,Diesel,1971
+95 000 ,Tunis,Peugeot 508,Diesel,2019
+41 500 ,Bizerte,CLIO 4 PREMIÈRE MAIN EN TRÈS BON ÉTAT,,
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+45 500 ,Beja,Great-wall MK-GT,Essence,2021
+32 000 ,Ben arous,Peugeot 308,Essence,2015
+61 ,Ben arous,Mazda MAZDA6,Essence,2018
+95 000 ,Tunis,Audi Q3,Essence,2019
+38 500 ,Bizerte,Volkswagen Golf 6,Diesel,2010
+22 000 ,Sousse,Peugeot 405,Diesel,1971
+95 000 ,Tunis,Peugeot 508,Diesel,2019
+41 500 ,Bizerte,CLIO 4 PREMIÈRE MAIN EN TRÈS BON ÉTAT,,
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+32 000 ,Ben arous,Peugeot 308,Essence,2015
+61 ,Ben arous,Mazda MAZDA6,Essence,2018
+95 000 ,Tunis,Audi Q3,Essence,2019
+38 500 ,Bizerte,Volkswagen Golf 6,Diesel,2010
+22 000 ,Sousse,Peugeot 405,Diesel,1971
+95 000 ,Tunis,Peugeot 508,Diesel,2019
+41 500 ,Bizerte,CLIO 4 PREMIÈRE MAIN EN TRÈS BON ÉTAT,,
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+61 ,Ben arous,Mazda MAZDA6,Essence,2018
+95 000 ,Tunis,Audi Q3,Essence,2019
+38 500 ,Bizerte,Volkswagen Golf 6,Diesel,2010
+22 000 ,Sousse,Peugeot 405,Diesel,1971
+95 000 ,Tunis,Peugeot 508,Diesel,2019
+41 500 ,Bizerte,CLIO 4 PREMIÈRE MAIN EN TRÈS BON ÉTAT,,
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+95 000 ,Tunis,Audi Q3,Essence,2019
+38 500 ,Bizerte,Volkswagen Golf 6,Diesel,2010
+22 000 ,Sousse,Peugeot 405,Diesel,1971
+95 000 ,Tunis,Peugeot 508,Diesel,2019
+41 500 ,Bizerte,CLIO 4 PREMIÈRE MAIN EN TRÈS BON ÉTAT,,
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+38 500 ,Bizerte,Volkswagen Golf 6,Diesel,2010
+22 000 ,Sousse,Peugeot 405,Diesel,1971
+95 000 ,Tunis,Peugeot 508,Diesel,2019
+41 500 ,Bizerte,CLIO 4 PREMIÈRE MAIN EN TRÈS BON ÉTAT,,
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+22 000 ,Sousse,Peugeot 405,Diesel,1971
+95 000 ,Tunis,Peugeot 508,Diesel,2019
+41 500 ,Bizerte,CLIO 4 PREMIÈRE MAIN EN TRÈS BON ÉTAT,,
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+95 000 ,Tunis,Peugeot 508,Diesel,2019
+41 500 ,Bizerte,CLIO 4 PREMIÈRE MAIN EN TRÈS BON ÉTAT,,
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+41 500 ,Bizerte,CLIO 4 PREMIÈRE MAIN EN TRÈS BON ÉTAT,,
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+25 000 ,Sfax,Mahindra KUV 100,Essence,2018
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+26 800 ,Ariana,Mahindra KUV 100,Essence,2018
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+65 000 ,Ariana,Volkswagen Golf,Essence,2019
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+17 ,Nabeul,Peugeot Partner,Diesel,2011
+41 000 ,Manouba,Skoda Octavia,Essence,2015
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+17 ,Nabeul,Peugeot Partner,Diesel,2011
+40 000 ,Zaghouan,Renault Autres,Essence,2017
+33 ,Nabeul,Hyundai I10,Essence,2020
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+17 ,Nabeul,Peugeot Partner,Diesel,2011
+40 000 ,Zaghouan,Renault Autres,Essence,2017
+39 900 ,Bizerte,Hyundai I10,Essence,2017
+37 000 ,Tunis,Kia RIO,Essence,2015
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+17 ,Nabeul,Peugeot Partner,Diesel,2011
+40 000 ,Zaghouan,Renault Autres,Essence,2017
+39 900 ,Bizerte,Hyundai I10,Essence,2017
+63 000 ,Tunis,Kia RIO,Essence,2022
+11 000 ,Nabeul,Opel Corsa,Essence,1999
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+17 ,Nabeul,Peugeot Partner,Diesel,2011
+40 000 ,Zaghouan,Renault Autres,Essence,2017
+39 900 ,Bizerte,Hyundai I10,Essence,2017
+63 000 ,Tunis,Kia RIO,Essence,2022
+28 886 696 ,Gabes,Renault Zoe,Essence,2010
+95 ,Ben arous,Volkswagen T-ROCK,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+17 ,Nabeul,Peugeot Partner,Diesel,2011
+40 000 ,Zaghouan,Renault Autres,Essence,2017
+39 900 ,Bizerte,Hyundai I10,Essence,2017
+63 000 ,Tunis,Kia RIO,Essence,2022
+28 886 696 ,Gabes,Renault Zoe,Essence,2010
+55 000 ,Tunis,Renault Kadjar,Essence,2019
+0 ,Sousse,Kuv100 /k8 toute neuve,,
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+17 ,Nabeul,Peugeot Partner,Diesel,2011
+40 000 ,Zaghouan,Renault Autres,Essence,2017
+39 900 ,Bizerte,Hyundai I10,Essence,2017
+63 000 ,Tunis,Kia RIO,Essence,2022
+28 886 696 ,Gabes,Renault Zoe,Essence,2010
+55 000 ,Tunis,Renault Kadjar,Essence,2019
+42 ,Nabeul,Volkswagen Caddy,Diesel,2017
+0 ,Manouba,Kia SPORTAGE,Hybride,2022
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+17 ,Nabeul,Peugeot Partner,Diesel,2011
+40 000 ,Zaghouan,Renault Autres,Essence,2017
+39 900 ,Bizerte,Hyundai I10,Essence,2017
+63 000 ,Tunis,Kia RIO,Essence,2022
+28 886 696 ,Gabes,Renault Zoe,Essence,2010
+55 000 ,Tunis,Renault Kadjar,Essence,2019
+42 ,Nabeul,Volkswagen Caddy,Diesel,2017
+185 000 ,Tunis,Mercedes Classe E,Essence,2017
+65 ,Manouba,Ssangyong Tivoli,Essence,2021
+21 000 ,Sousse,Chery QQ,Essence,2018
+36 ,Nabeul,Dacia SANDERO,Essence,2014
+28 000 ,Ariana,Peugeot 208,Essence,2016
+90 ,Tunis,Mercedes Classe C,Essence,2016
+16 000 ,Ben arous,Volkswagen Polo,Essence,2001
+13 200 ,Manouba,Volkswagen Polo,Essence,1998
+11 111 ,Ariana,Renault Clio,Essence,2003
+18 000 ,Tunis,Chevrolet AVEO,Essence,2012
+41 000 ,Sfax,Kia RIO,Essence,2018
+30 000 ,Manouba,Peugeot 108,Essence,2017
+50 ,Tunis,Ssangyong Actyon,Diesel,2017
+111 ,Gabes,Peugeot 106,Essence,1994
+34 ,Sousse,Peugeot 208,Essence,2019
+34 ,Ariana,Suzuki Swift,Essence,2018
+34 000 ,Tunis,Hyundai I20,Essence,2016
+42 500 ,Tunis,Chery Tiggo 2,Essence,2020
+45 000 ,Tunis,Audi A4,Essence,2013
+80 000 ,Ariana,Honda CIVIC,Essence,2020
+14 500 ,Ariana,Fiat PALIO WEEKEND,Essence,2008
+11 900 ,Tunis,Peugeot 106,Essence,1997
+20 500 ,Tunis,Ford AUTRE,Essence,2013
+0 ,Ben arous,Seat Ibiza,Essence,2023
+63 500 ,Tunis,Kia RIO,Essence,2022
+1 ,Ariana,Bmw AUTRE,Diesel,2009
+62 500 ,Ben arous,Renault Clio,Essence,2024
+33 500 ,Sousse,Volkswagen Golf,Diesel,2012
+37 ,Bizerte,Audi A4,Essence,2012
+26 500 ,Nabeul,Peugeot 207,Essence,2012
+25 000 ,Nabeul,Citroen C4,Essence,2012
+30 000 ,Siliana,Ford focus a vendre,,
+80 000 ,Sfax,Mercedes Classe Glk,Essence,2009
+34 500 ,Tunis,Volkswagen Jetta,Essence,2011
+23 500 ,Ben arous,Peugeot 206,Essence,2012
+105 000 ,Mahdia,Peugeot 3008,Essence,2020
+80 000 ,Sfax,Mercedes Classe C,Essence,2012
+44 000 ,Sfax,Renault Clio,Essence,2021
+15 800 ,Ben arous,Volkswagen Golf 3,Diesel,1995
+1 ,Manouba,Citroen AUTRE,Essence,2017
+23 500 ,Tunis,Citroen AUTRE,Essence,2015
+95 ,Gafsa,Golf 8 neuf,,
+17 ,Nabeul,Peugeot Partner,Diesel,2011
+40 000 ,Zaghouan,Renault Autres,Essence,2017
+39 900 ,Bizerte,Hyundai I10,Essence,2017
+63 000 ,Tunis,Kia RIO,Essence,2022
+28 886 696 ,Gabes,Renault Zoe,Essence,2010
+55 000 ,Tunis,Renault Kadjar,Essence,2019
+42 ,Nabeul,Volkswagen Caddy,Diesel,2017
+185 000 ,Tunis,Mercedes Classe E,Essence,2017
+135 000 ,Tunis,Hyundai TUCSON,Diesel,2022

--- a/data/preset1_mileage_fixed.csv
+++ b/data/preset1_mileage_fixed.csv
@@ -1,0 +1,829 @@
+Price,Title,Fuel,Mileage,Year
+35 000,KIA Rio Berline,Essence,163746.0,2016
+105 000,Peugeot 3008,Essence,55000.0,2022
+30 500,Renault Clio Campus climatisée,Essence,116000.0,2012
+52 000,Chery Tiggo 3X Luxury,Essence,47000.0,2022
+32 000,Peugeot 3008,Essence,210000.0,2010
+52 000,KIA Rio Berline,Essence,90500.0,2020
+43 500,Hyundai Grand i10,Essence,43200.0,2021
+58 000,MG 5,Essence,37000.0,2022
+73 500,Mercedes-Benz Classe C,Essence,159000.0,2012
+260 000,Mercedes-Benz GLC Coupé AMG,Hybride,47000.0,2021
+77 000,Haval H6 Luxury,Essence,100000.0,2019
+67 000,Mercedes-Benz Classe E,Essence,197000.0,2010
+178 000,Mercedes-Benz Classe C coupé AMG,Hybride,86000.0,2019
+122 000,Land Rover Range Rover Evoque R-Dynamic,Diesel,150000.0,2016
+145 000,BMW Série 4 Gran Coupé,Essence,90000.0,2019
+258 000,Land Rover Range Rover Velar R-Dynamic,Diesel,55000.0,2020
+189 000,Mercedes-Benz GLA AMG,Essence,20000.0,2023
+97 500,Hyundai Kona Hybride N Line,Hybride,19500.0,2020
+112 000,Audi Q3,Essence,110000.0,2019
+152 000,Porsche Cayenne,Essence,195000.0,2012
+103 000,MG HS Trophy,Essence,35000.0,2021
+122 000,Mercedes-Benz Classe S S 350 phase 2,Essence,165000.0,2010
+Sous leasing                    161 300,Mercedes-Benz Classe C AMG,Essence,135000.0,2019
+72 000,Volkswagen Golf 7 Join,Essence,83000.0,2018
+98 000,Mercedes-Benz Classe S S350. Toit ouvrant,Essence,147000.0,2009
+56 000,Peugeot Partner Origin Utilitaire Pack Clim PM,Diesel,73000.0,2019
+95 000,KIA Sportage GT-Line,Diesel,139000.0,2018
+155 000,Cupra Formentor Sport,Essence,41000.0,2022
+165 000,Mercedes-Benz Classe C AMG,Hybride,54000.0,2018
+165 000,Mercedes-Benz Classe C AMG,Hybride,69000.0,2020
+75 000,Volkswagen Golf 7 Confortline,Essence,69000.0,2020
+51 000,KIA Rio 5p,Essence,145000.0,2019
+145 000,Mercedes-Benz Classe A,Hybride,66000.0,2021
+95 000,Volkswagen Golf 7,Essence,88000.0,2018
+55 000,BMW Série 1,Essence,144000.0,2015
+76 500,Volkswagen Golf 7 Join,Essence,120000.0,2020
+199 000,BMW X2 Lounge,Essence,0.0,2024
+169 000,Land Rover Range Rover Evoque R-Dynamic,Diesel,59000.0,2021
+110 000,Volkswagen Golf 8 R-Line,Hybride,12000.0,2022
+122 000,Mercedes-Benz GLA AMG,Essence,30000.0,2018
+259 000,Mercedes-Benz GLC Coupé AMG,Hybride,50000.0,2021
+174 000,Mercedes-Benz Classe C AMG +,Essence,60000.0,2021
+155 000,Volkswagen T-roc 1.5,Hybride,9000.0,2024
+197 000,Mercedes-Benz Classe C AMG,Essence,32000.0,2022
+218 000,Land Rover Range Rover Evoque R-Dynamic S,Hybride,59000.0,2021
+115 000,Volkswagen Golf 8,Hybride,40000.0,2020
+248 000,Mercedes-Benz Classe C AMG +,Hybride,11000.0,2024
+89 500,Suzuki Jimny,Essence,60000.0,2021
+68 000,Mercedes-Benz Classe E coupé AMG,Essence,180000.0,2010
+98 000,Volkswagen T-roc Toit ouvrant,Essence,44000.0,2020
+99 500,Mercedes-Benz Classe C AMG,Essence,180000.0,2016
+184 000,Mercedes-Benz GLB AMG,Essence,16000.0,2023
+435 000,Mercedes-Benz Classe E AMG,Hybride,0.0,2024
+109 000,Mercedes-Benz Classe C AMG,Essence,175000.0,2016
+124 500,BMW Série 5 Luxury Line,Essence,155000.0,2017
+169 000,Mercedes-Benz Classe A A200,Hybride,8000.0,2024
+149 000,KIA Sportage GT-Line,Hybride,40000.0,2023
+268 000,Land Rover Range Rover Velar R-Dynamic,Essence,33000.0,2019
+158 000,BMW Série 7 B7 ALPINA,Essence,115000.0,2011
+89 500,Volkswagen Golf 8 ÉDITION,Essence,45000.0,2021
+450 000,Mercedes-Benz Classe E AMG,Hybride,0.0,2024
+415 000,Mercedes-Benz GLC Coupé AMG,Essence,0.0,2024
+169 000,Mercedes-Benz CLA AMG,Hybride,42000.0,2020
+295 000,Audi Q5 Sportback S-Line,Hybride,45000.0,2022
+124 000,Mercedes-Benz Classe A A 200,Essence,57000.0,2018
+188 000,Mercedes-Benz CLA AMG,Essence,30000.0,2023
+178 000,Land Rover Range Rover Sport,Essence,180000.0,2014
+535 000,Porsche Panamera 4S E-hybride plugin,Hybride,32000.0,2021
+225 000,Mercedes-Benz GLC Coupé AMG,Essence,106000.0,2016
+175 000,Audi Q3 Sportback hybrid,Hybride,50000.0,2021
+380 000,Porsche Cayenne Coupé,Essence,37000.0,2020
+269 000,Jaguar F-Pace R-Dynamic S,Essence,27000.0,2021
+129 000,BMW X1 FACELIFT PACK M,Essence,87000.0,2020
+168 000,Mitsubishi L200 Sportero,Diesel,19000.0,2022
+510 000,Porsche Cayenne,Hybride,15000.0,2022
+147 000,Audi A5 Sportback S-Line,Essence,85000.0,2020
+88 000,Mercedes-Benz ML,Diesel,231000.0,2010
+148 000,Mercedes-Benz CLA,Diesel,93000.0,2020
+98 000,BMW X6,Essence,180000.0,2011
+245 000,Mercedes-Benz GLC Coupé,Hybride,70000.0,2020
+350 000,Mercedes-Benz Classe G,Diesel,168000.0,2010
+85 000,Peugeot 508,Essence,46000.0,2020
+132 000,Seat Leon Cupra,Essence,74000.0,2020
+48 000,Volkswagen Touareg,Diesel,308000.0,2006
+195 000,Mercedes-Benz Classe S,Hybride,79000.0,2015
+83 000,Peugeot 508,Essence,137000.0,2019
+340 000,Land Rover Range Rover Sport,Hybride,100000.0,2019
+178 000,BMW Série 5,Essence,93000.0,2020
+400 000,Mercedes-Benz GLC Coupé,Essence,0.0,2024
+208 000,BMW Série 5,Essence,32000.0,2021
+630 000,Mercedes-Benz Classe G AMG,Essence,30000.0,2015
+158 000,Mercedes-Benz GLC,Essence,83000.0,2016
+174 000,Mercedes-Benz CLA,Hybride,69000.0,2021
+30 500,Citroën DS3,Essence,92000.0,2017
+100 000,Mini Clubman,Essence,34000.0,2019
+450 000,Mercedes-Benz Classe S,Hybride,40000.0,2020
+95 000,Nissan Qashqai,Essence,26000.0,2022
+245 000,Mercedes-Benz Classe E,Essence,9000.0,2022
+360 000,Mercedes-Benz GLC Coupé,Essence,6600.0,2023
+170 000,Audi A5 Sportback,Essence,58000.0,2021
+98 000,Seat Ateca,Essence,85000.0,2020
+410 000,Porsche Cayenne E-Hybrid,Hybride,86000.0,2019
+54 500,KIA Picanto GT-Line,Essence,63000.0,2022
+88 000,Toyota Prado,Diesel,449000.0,2003
+47 000,BYD F3,Essence,10000.0,2022
+350 000,Land Rover Range Rover Sport,Hybride,37000.0,2020
+115 000,Volkswagen Golf 7,Essence,73000.0,2017
+375 000,Porsche Macan,Essence,6900.0,2023
+174 000,BMW Série 3,Essence,80000.0,2021
+190 000,Audi Q3,Essence,2000.0,2024
+370 000,Porsche Cayenne Coupé,Essence,59000.0,2019
+350 000,Toyota Land Cruiser,Diesel,98000.0,2016
+58 000,Mini 5 portes,Essence,75000.0,2015
+340 000,Mercedes-Benz Classe E coupé,Hybride,86000.0,2018
+82 000,Peugeot 3008,Essence,87000.0,2019
+56 000,Toyota RAV 4,Essence,280000.0,2016
+45 500,Fiat 500 C,Essence,71000.0,2017
+240 000,Mercedes-Benz GLC Coupé,Diesel,52000.0,2020
+42 000,Suzuki Swift,Essence,69000.0,2020
+76 000,Toyota Corolla,Essence,32000.0,2022
+92 500,Ssangyong Korando,Essence,80000.0,2021
+225 000,Jeep Wrangler Sahara,Essence,115000.0,2018
+40 000,Peugeot 2008 Allure,Essence,96000.0,2015
+100 000,BMW Série 4 Gran Coupé,Essence,121000.0,2019
+95 000,Volkswagen Tiguan,Essence,123000.0,2021
+59 000,BMW Série 3 318i,Essence,200000.0,2015
+25 500,Peugeot 307,Essence,110451.0,2007
+118 000,Mercedes-Benz Classe A AMG,Diesel,96000.0,2019
+139 500,Mini Countryman All4,Hybride,33000.0,2020
+58 000,MG ZS,Essence,110000.0,2021
+245 000,Mercedes-Benz Classe C,Essence,7300.0,2022
+120 000,KIA Sportage Hybride,Hybride,53000.0,2020
+115 000,BMW Série 1 Pack M,Essence,110.0,2020
+55 000,Fiat 500 Dolcevita,Hybride,78000.0,2021
+49 500,Fiat Tipo 5 portes,Essence,68000.0,2021
+49 500,Renault Clio,Diesel,138000.0,2020
+99 000,Mercedes-Benz Classe C,Essence,158000.0,2015
+39 500,Suzuki Celerio,Essence,0.0,2024
+48 500,Volkswagen Golf 7,Essence,153000.0,2015
+59 500,Renault Megane,Diesel,148000.0,2021
+45 500,Peugeot 208 Style,Diesel,128000.0,2020
+78 000,Audi Q5 S-line,Diesel,270000.0,2014
+38 500,Citroën C1 Importée Tn245,Essence,56000.0,2021
+76 000,Haval H6 Luxury,Essence,138000.0,2021
+79 000,Peugeot 3008,Diesel,148000.0,2020
+57 000,Volkswagen Amarok TDI 4*4,Diesel,198000.0,2012
+145 000,Mercedes-Benz CLA AMG,Diesel,138000.0,2020
+118 000,Mercedes-Benz CLA Importée Tn245,Diesel,138000.0,2020
+149 000,Mercedes-Benz CLA,Essence,87000.0,2021
+110 000,Volkswagen Golf 8 STYLE 1.5 BVA eTSI  importée,Essence,87000.0,2021
+98 000,KIA Sportage GT-Line,Diesel,119000.0,2019
+99 000,Haval H6,Essence,16000.0,2022
+185 000,BMW Série 5 Pack M,Essence,70000.0,2021
+107 000,BMW Série 4 Gran Coupé,Essence,53000.0,2020
+30 000,Hyundai Grand i10 Sedan,Essence,150000.0,2017
+135 000,Mercedes-Benz Classe C AMG +,Essence,146000.0,2015
+95 000,Volkswagen Golf 8 Active,Essence,69000.0,2021
+420 000,Mercedes-Benz GLE Coupé,Diesel,54000.0,2020
+115 000,Mazda CX-5 High Grade,Essence,63000.0,2019
+65 000,MG ZS,Essence,65000.0,2019
+70 000,Seat Leon,Essence,61847.0,2020
+97 000,Mercedes-Benz CLA Urban,Essence,125043.0,2018
+150 000,KIA Sportage Hybride GT-Line,Hybride,36000.0,2023
+54 000,KIA Rio 5p SX,Essence,68954.0,2019
+75 000,Volkswagen Golf 7 Highline,Essence,26043.0,2016
+87 000,Volkswagen Golf 8 Life,Essence,70001.0,2020
+175 000,Toyota Land Cruiser,Diesel,142060.0,2010
+69 000,Volkswagen Golf 7 Confortline,Essence,169452.0,2019
+40 000,BMW Série 1,Essence,131766.0,2009
+165 000,Mercedes-Benz Classe E AMG,Essence,55001.0,2019
+275 000,Mercedes-Benz Classe C AMG +,Essence,0.0,2024
+235 000,Mercedes-Benz GLA La nouvelle Gla 250e AMG,Hybride,10730.0,2023
+390 000,Mercedes-Benz Classe E AMG,Essence,10776.0,2023
+65 000,BMW X3 Luxury Line,Diesel,186000.0,2006
+185 000,Mercedes-Benz Classe C AMG,Essence,50893.0,2022
+43 000,KIA Picanto Populaire,Essence,3805.0,2021
+36 000,Lada 4x4 Urban,Essence,24387.0,2018
+126 000,Haval H6,Essence,12442.0,2023
+51 000,Nissan Juke Tekna,Essence,163166.0,2014
+160 000,Mitsubishi Pajero LIMITED EDITION,Diesel,20742.0,2023
+169 900,Mercedes-Benz CLA AMG Edition 1,Hybride,31235.0,2021
+64 000,Peugeot 308 GT-Line GT-Line,Diesel,96300.0,2020
+129 000,Toyota Prado,Diesel,199425.0,2003
+135 000,Mini 5 portes,Essence,18000.0,2021
+62 000,BMW Série 3 coupé,Essence,156000.0,2010
+30 000,Mahindra KUV 100 K6+,Essence,63000.0,2021
+93 000,Haval Jolion 1 ere,Essence,30000.0,2023
+126 000,Peugeot 308,Diesel,48000.0,2023
+198 000,Volkswagen Tiguan R-Line,Essence,54723.0,2023
+59 000,Peugeot Expert,Diesel,139199.0,2019
+138 000,Volkswagen Golf 8 R-Line,Hybride,36651.0,2022
+48 000,Mini Cabrio,Essence,86111.0,2010
+61 000,KIA Picanto 1 ère main,Essence,0.0,2024
+275 000,Porsche Cayman S,Essence,39508.0,2008
+54 000,Seat Ibiza,Essence,99519.0,2021
+119 000,Toyota Land Cruiser,Diesel,316620.0,2003
+230 000,Mercedes-Benz GLC Coupé AMG,Hybride,82415.0,2020
+65 000,Mercedes-Benz Classe C AMG,Essence,249000.0,2011
+178 000,Mercedes-Benz Classe C,Essence,30570.0,2021
+71 000,Peugeot 3008,Essence,105000.0,2017
+225 000,Mercedes-Benz CLA AMG,Hybride,1000.0,2024
+88 000,Volkswagen Golf 8,Essence,85181.0,2020
+79 000,Volkswagen Golf 7 Join,Essence,86000.0,2018
+78 000,Volkswagen T-roc,Essence,74107.0,2019
+36 000,Renault Symbol,Essence,115000.0,2020
+185 000,Mercedes-Benz CLA AMG,Hybride,18500.0,2023
+135 000,Mercedes-Benz Classe A AMG,Essence,68000.0,2018
+65 000,BMW Série 3 Luxury,Essence,112000.0,2013
+110 000,Audi Q5 S-line,Diesel,176000.0,2015
+145 000,Mercedes-Benz Classe C AMG,Diesel,145000.0,2019
+50 000,Peugeot 2008 Allure Toit Cielo Blanc Nacré,Essence,125000.0,2018
+119 000,Mercedes-Benz Classe A AMG,Diesel,141000.0,2019
+145 000,Volkswagen Golf 8 GTE,Hybride,26000.0,2021
+220 000,Mercedes-Benz CLA AMG,Hybride,6000.0,2024
+78 000,Mercedes-Benz Classe A AMG Premium,Essence,131000.0,2013
+46 500,KIA Picanto,Essence,28000.0,2021
+48 000,Ford Fusion Titanium,Essence,217000.0,2016
+49 800,Mini 5 portes Très bon état,Essence,160000.0,2016
+45 000,BMW Série 3,Essence,180000.0,2012
+60 000,Seat Leon 1.2L,Essence,140000.0,2018
+200 000,Land Rover Range Rover Sport,Essence,190000.0,2015
+89 000,Peugeot 3008 1.2L,Essence,70000.0,2020
+87 000,Volkswagen Golf 8,Essence,58000.0,2022
+89 000,KIA Sportage 1.6L Diesel,Diesel,105000.0,2018
+55 500,Mercedes-Benz Classe C,Essence,235000.0,2013
+47 000,Audi Q5 2.0L,Essence,255000.0,2009
+139 000,Volkswagen Golf 8,Essence,40000.0,2023
+89 000,Mercedes-Benz Classe C AMG,Essence,164000.0,2014
+138 000,Mercedes-Benz Classe E 1.6L,Essence,132000.0,2017
+108 000,Seat Leon Xcellence,Essence,37000.0,2023
+72 000,Jeep Wrangler 4.0L,Essence,200000.0,1989
+38 500,Renault Clio 1.0L,Essence,135000.0,2021
+78 500,Audi A3 Sportback 1.2L,Essence,125000.0,2019
+119 000,Cupra Formentor 1.5L,Hybride,19000.0,2022
+55 500,Ford Fusion 1.6,Essence,90000.0,2017
+49 500,Mazda 3,Essence,124000.0,2017
+39 500,Nissan Juke,Essence,160000.0,2015
+227 000,Volvo XC60 2.0L,Essence,18000.0,2022
+39 800,Hyundai Grand i10 1.0L,Essence,57000.0,2021
+43 000,Skoda Fabia 1.6L,Essence,137000.0,2018
+75 000,BMW Série 5 520,Essence,182000.0,2014
+93 000,Volkswagen Golf 8 1.5L,Essence,80000.0,2021
+132 000,BMW X2 S drive,Essence,74000.0,2020
+73 500,Volkswagen Golf 7 Importé,Essence,40000.0,2020
+85 000,BMW X1 1.6L,Essence,126000.0,2016
+138 500,BMW Série 1 M,Essence,40000.0,2022
+58 500,Citroën Berlingo Utilitaire 1.6L,Diesel,31000.0,2023
+38 000,Citroën C3,Essence,92000.0,2018
+34 500,Citroën C3 Live,Essence,119000.0,2019
+38 000,Citroën C4,Essence,109000.0,2012
+88 000,Peugeot 3008 Allure,Essence,38000.0,2019
+159 000,Mercedes-Benz Classe C Avantgarde,Essence,27000.0,2022
+75 000,Peugeot 3008 Allure,Essence,75000.0,2020
+139 000,BMW X4,Diesel,140000.0,2018
+65 500,Volkswagen Polo R-Line,Essence,70000.0,2020
+69 000,Volkswagen Golf 7 BVA,Essence,200000.0,2020
+75 000,BMW Série 1 Pack Sport M,Essence,165000.0,2016
+147 000,Hyundai Tucson Top Grade,Essence,40000.0,2022
+41 000,Lada 4x4 Urban,Essence,58000.0,2020
+205 000,Mercedes-Benz Classe X,Diesel,68000.0,2020
+81 000,Seat Arona Xperience,Essence,47000.0,2022
+69 000,Toyota Corolla Dynamic,Essence,85000.0,2020
+65 000,Fiat 500X Pop Star,Essence,60000.0,2018
+115 000,Land Rover Discovery,Essence,170000.0,2015
+88 000,Haval Jolion,Essence,40000.0,2021
+73 000,Toyota C-HR,Essence,130000.0,2018
+92 500,Nissan Juke Tekna,Essence,6000.0,2024
+Sous leasing                    255 100,Mercedes-Benz Classe C AMG,Essence,20000.0,2023
+129 000,Mercedes-Benz CLA Kit Amg 200,Essence,150000.0,2020
+62 000,Seat Ibiza Xcellence,Essence,68000.0,2021
+57 500,KIA Rio 5p SX,Essence,70000.0,2020
+72 000,MG ZS Luxury,Essence,20000.0,2022
+101 000,Chery Tiggo 7 Pro,Essence,0.0,2024
+165 000,Audi Q3 BVA,Essence,3000.0,2023
+155 000,Peugeot 408 GT,Essence,10000.0,2024
+87 000,Jaguar XF Luxury,Essence,120000.0,2014
+85 000,BMW Série 6 Face Lift,Essence,190000.0,2009
+189 000,Land Rover Range Rover Sport HSE Dynamic,Diesel,300000.0,2016
+62 000,KIA Rio 5p GT-Line,Essence,70000.0,2021
+188 000,KIA Sportage GT-Line,Hybride,15000.0,2024
+225 000,Mercedes-Benz GLA 250e Pack AMG,Hybride,26000.0,2023
+39 000,Mahindra Pick-up SC,Diesel,120000.0,2021
+69 000,Peugeot 3008,Essence,112000.0,2020
+73 000,KIA Rio 5p GT-Line,Essence,9000.0,2023
+152 000,Mercedes-Benz Classe C Pack AMG Pack night,Hybride,120000.0,2019
+89 000,Peugeot 3008 GT GT-line,Essence,125000.0,2020
+77 900,MG HS Luxury,Essence,87000.0,2020
+173 000,Mercedes-Benz GLA AMG,Essence,90000.0,2021
+87 000,BMW Série 4 Coupé 420i,Essence,180000.0,2015
+88 000,Chery Tiggo 7 Pro,Essence,40000.0,2022
+98 000,Suzuki Jimny,Essence,20000.0,2023
+83 000,Mercedes-Benz CLA Kit AMG,Essence,124000.0,2014
+37 500,Citroën C3 Shine,Essence,88000.0,2018
+63 000,Mercedes-Benz Classe C coupé AMG,Essence,200000.0,2012
+45 000,Renault Clio 4,Essence,120000.0,2021
+29 000,Mini 3 portes One,Essence,200000.0,2009
+129 000,Hyundai Tucson High Grade,Essence,19000.0,2023
+87 000,Nissan Juke Tekna,Essence,53000.0,2021
+88 000,Jeep Renegade,Essence,88000.0,2021
+152 000,Mercedes-Benz Classe C AMG,Hybride,120000.0,2019
+109 000,Ford Mondeo Hybride,Hybride,34000.0,2020
+120 000,Land Rover Range Rover Evoque,Diesel,145000.0,2018
+59 000,Volkswagen Passat,Essence,160000.0,2016
+117 000,Haval H6,Essence,16000.0,2022
+85 000,Haval H6 Luxury,Essence,55000.0,2021
+105 000,Volkswagen Golf 8 1.4,Essence,40000.0,2022
+179 000,Jaguar F-Pace R_Dynamic,Diesel,165000.0,2017
+70 000,Renault Kadjar,Essence,140000.0,2018
+79 000,Toyota Corolla,Essence,24000.0,2022
+47 000,Peugeot 308,Essence,128000.0,2020
+167 000,Mercedes-Benz Classe C coupé AMG,Essence,130000.0,2018
+47 500,Citroën C3 Shine,Essence,45000.0,2020
+40 000,Ford Focus Titanium,Essence,200000.0,2015
+178 000,Porsche Panamera,Essence,82000.0,2011
+89 000,KIA Seltos,Essence,130000.0,2021
+81 000,Seat Ibiza FR,Essence,40000.0,2023
+77 000,Alfa Romeo Giulietta,Essence,37000.0,2019
+235 000,Land Rover Discovery R-DYNAMIC,Diesel,87000.0,2020
+49 000,Volkswagen Golf 7 Confortline,Essence,190000.0,2013
+64 500,Renault Megane 4 Diesel,Diesel,125000.0,2020
+65 000,KIA Rio 5p GT-Line,Essence,60000.0,2021
+35 000,Fiat Fiorino,Diesel,120000.0,2021
+75 000,Dacia Duster Techroad,Essence,35000.0,2020
+278 000,BMW Série 5 530e Xdrive Pack m,Hybride,50000.0,2021
+97 000,BMW Série 4 Gran Coupé 418 Luxury,Essence,133000.0,2016
+125 000,Volkswagen Passat R-Line DSG,Essence,40000.0,2022
+290 000,Toyota Hilux Double Cabine Gr Sport,Diesel,7000.0,2024
+91 000,Toyota C-HR,Essence,55000.0,2022
+109 000,Audi A5 Sportback S-Line,Essence,120000.0,2019
+80 000,Peugeot 2008,Diesel,100000.0,2021
+Sous leasing                    59 700,KIA Rio 5p,Essence,85000.0,2022
+91 000,Honda CR-V,Essence,67000.0,2018
+295 000,Audi Q5 S-line,Diesel,40000.0,2021
+107 000,KIA Sportage Hybride,Hybride,114000.0,2021
+128 000,KIA Sportage GT-Line,Diesel,19000.0,2021
+76 000,Dacia Duster Techroad,Essence,34000.0,2020
+660 000,Mercedes-Benz Classe S AMG,Hybride,3000.0,2022
+455 000,BMW X5 Hybride Xdrive E45,Hybride,19000.0,2021
+138 000,Hyundai Tucson Hybride Xcellence,Hybride,120000.0,2022
+75 000,BMW Série 1 I Pack Sport,Essence,200000.0,2019
+105 000,KIA Sportage GT-Line,Diesel,140000.0,2017
+235 000,Mercedes-Benz Classe C AMG,Essence,50000.0,2023
+120 000,Jaguar XE,Diesel,140000.0,2017
+72 000,Peugeot Rifter,Diesel,95000.0,2020
+110 000,BMW Série 7 740LI,Essence,98000.0,2010
+72 000,Peugeot Rifter 5 places,Diesel,95000.0,2020
+187 000,Land Rover Range Rover Evoque Hybride,Diesel,50000.0,2019
+115 000,Ford Mondeo Hybride,Hybride,32000.0,2020
+64 000,KIA Rio 5p GT-Line,Essence,64000.0,2021
+169 000,Mercedes-Benz GLC AMG,Essence,115000.0,2017
+57 000,Mini 5 portes One,Essence,78000.0,2016
+48 000,Citroën C3 Shine,Essence,28000.0,2020
+85 000,Audi A3 Berline,Essence,50000.0,2019
+83 500,KIA Sportage,Essence,127000.0,2019
+Non dédouané                    235 000,Mercedes-Benz GLA AMG,Essence,12000.0,2023
+95 000,Audi Q3,Essence,95000.0,2017
+210 000,Mercedes-Benz GLB 200 d,Diesel,111000.0,2021
+58 000,Audi A4 Face_lift,Essence,143000.0,2016
+95 000,Land Rover Range Rover Evoque Face_lift,Essence,170000.0,2016
+135 000,BMW Série 1 Pack M,Essence,40000.0,2020
+195 000,Land Rover Range Rover Evoque Hybride,Diesel,40000.0,2019
+79 000,Haval H6 Luxury,Essence,120000.0,2020
+105 000,Iveco Daily Simple Cabine,Diesel,40000.0,2022
+128 000,Land Rover Discovery Sport,Diesel,128000.0,2017
+90 000,Haval H6 Luxury,Essence,40000.0,2021
+98 000,KIA Sportage Hybride,Hybride,140000.0,2020
+85 000,KIA Sportage,Essence,125000.0,2019
+137 000,Hyundai Tucson Hybride,Hybride,80000.0,2021
+165 000,Audi Q5 QUATTRO 40 TDI,Diesel,170000.0,2019
+43 500,Fiat Panda City Cross,Essence,52000.0,2020
+45 000,Volkswagen Golf 6 Match,Diesel,240000.0,2012
+228 000,Ford Ranger Raptor,Diesel,100000.0,2022
+130 000,BMW Série 4 Coupé Pack M,Essence,140000.0,2021
+48 000,Mercedes-Benz Classe B,Essence,100000.0,2014
+75 000,MG ZS Luxury,Essence,80000.0,2022
+210 000,Land Rover Range Rover Evoque Hybride,Diesel,60000.0,2019
+68 000,Renault Kadjar,Essence,70000.0,2019
+56 000,Mazda 3 Sky active,Essence,103000.0,2017
+398 000,Audi Q8 S_Line,Essence,16000.0,2021
+173 000,Mercedes-Benz Classe C coupé AMG,Essence,50000.0,2019
+Sous leasing                    78 000,MG ZS,Essence,35000.0,2022
+40 000,Suzuki Baleno,Essence,160000.0,2017
+95 000,KIA Sportage,Essence,69000.0,2019
+69 000,Ford Kuga,Essence,100000.0,2017
+119 000,Mercedes-Benz CLS AMG,Diesel,160000.0,2011
+185 000,Mercedes-Benz GLA 180 Pack AMG,Essence,40000.0,2022
+73 500,Seat Arona,Essence,26000.0,2021
+71 000,Toyota Corolla,Essence,90000.0,2021
+79 000,Haval H6 Luxury,Essence,115000.0,2020
+125 000,Skoda Superb Ambassador,Essence,30000.0,2021
+79 000,MG 6,Essence,22000.0,2021
+189 000,Mercedes-Benz GLC Coupé AMG,Diesel,190000.0,2017
+89 000,Mercedes-Benz Classe C 180 elegance,Essence,170000.0,2016
+278 000,Mercedes-Benz GLC Coupé AMG,Hybride,69000.0,2020
+135 000,Mercedes-Benz Classe E 180,Essence,90000.0,2018
+42 000,Ssangyong Actyon Sports,Diesel,200000.0,2017
+35 000,DS 3,Essence,138000.0,2012
+97 000,Audi A3 Berline,Essence,17000.0,2020
+43 000,Nissan Qashqai,Essence,147000.0,2011
+90 000,BMW Série 5 Confort Luxury,Essence,200000.0,2015
+101 000,Volkswagen Passat R-Line,Essence,100000.0,2019
+125 000,Land Rover Discovery Sport,Diesel,160000.0,2017
+44 500,Citroën C3 Shine,Essence,90000.0,2019
+49 000,Volkswagen Amarok,Diesel,370000.0,2012
+Sous leasing                    291 800,Mercedes-Benz Classe E Business,Essence,8000.0,2022
+37 000,Mini 3 portes one,Essence,140000.0,2013
+68 000,BMW Série 1,Essence,126000.0,2017
+231 000,Toyota Hilux Double Cabine 4*4,Essence,3000.0,2024
+97 000,Peugeot 2008 Allure,Essence,34000.0,2022
+158 000,Mercedes-Benz Classe A AMG,Essence,20000.0,2022
+106 000,Volkswagen Passat R-Line,Essence,60000.0,2020
+90 000,Volkswagen Tiguan,Essence,60000.0,2018
+99 000,Mercedes-Benz Classe C AMG,Essence,160000.0,2014
+96 000,Chery Tiggo 8 Pro,Essence,80000.0,2022
+47 000,BYD F3,Essence,10000.0,2022
+44 500,Citroën C3 Shine,Essence,58000.0,2019
+107 000,BMW Série 4 Coupé 420i Pack M,Essence,160000.0,2015
+90 000,Audi Q3 S-line,Essence,100000.0,2017
+109 000,Volkswagen Golf 8 United,Essence,26000.0,2020
+35 000,Peugeot 208,Essence,60000.0,2020
+59 000,Audi A5 Cabriolet S-line,Essence,120000.0,2010
+135 000,Honda Accord,Essence,11000.0,2022
+74 000,Volkswagen Golf 7,Essence,40000.0,2019
+119 000,KIA Sportage,Essence,40000.0,2020
+135 000,BMW Série 2 Gran Coupé 218i,Essence,21000.0,2022
+46 000,Fiat Tipo 5 portes,Essence,75000.0,2018
+Sous leasing                    150 600,Haval H6,Essence,13000.0,2022
+52 000,Volkswagen Golf 7 Smartline,Essence,140000.0,2015
+78 000,Haval H6 Luxury,Essence,90000.0,2019
+40 000,Chevrolet Cruze,Essence,90000.0,2018
+76 000,Volkswagen Golf 7,Essence,29000.0,2019
+51 000,Mercedes-Benz Classe E 200,Essence,330000.0,2010
+77 000,Mercedes-Benz Classe E e220,Diesel,330000.0,2011
+145 000,Volkswagen Golf 8 R-Line,Essence,40000.0,2021
+240 000,Mercedes-Benz Classe C AMG,Essence,16000.0,2023
+Non dédouané                    212 000,Dodge RAM Rumble bee,Essence,65000.0,2019
+81 000,Mercedes-Benz CLA,Essence,163000.0,2014
+69 000,Haval H2 Luxury,Essence,40000.0,2019
+86 000,Haval H6 Luxury,Essence,32000.0,2019
+169 000,Mercedes-Benz CLA AMG,Essence,30000.0,2021
+98 000,Mercedes-Benz Classe A 180d,Diesel,50000.0,2019
+74 000,Volkswagen Golf 7,Essence,64000.0,2019
+95 000,Audi A3 Sportback S-Line,Essence,70000.0,2019
+205 000,Mercedes-Benz Classe C AMG,Essence,40000.0,2022
+105 000,DS 7 Crossback Grand Chic,Essence,140000.0,2021
+Sous leasing                    264 200,Mercedes-Benz Classe C AMG,Essence,50000.0,2022
+84 000,Volkswagen Golf 7 Join,Essence,70000.0,2018
+79 000,Mercedes-Benz CLA 220,Diesel,240000.0,2013
+110 000,BMW X6 Pack M,Diesel,270000.0,2008
+59 000,Audi A5 Cabriolet S-line,Essence,120000.0,2010
+73 000,Seat Leon Style,Essence,65000.0,2020
+37 500,Citroën Berlingo Utilitaire,Diesel,170000.0,2018
+143 000,KIA Sportage,Essence,23000.0,2022
+64 000,Volkswagen Golf 7,Essence,180000.0,2019
+78 000,Mercedes-Benz Classe S Executive,Essence,170000.0,2008
+128 000,Volkswagen Tiguan Confortline,Essence,33000.0,2020
+80 000,Volkswagen Golf 7 R-Line,Essence,130000.0,2018
+79 000,Hyundai Kona,Hybride,30000.0,2021
+Sous leasing                    122 800,Seat Leon FR,Essence,70000.0,2022
+53 000,Hyundai Grand i10,Essence,30000.0,2022
+92 000,Peugeot 2008 GT_LINE,Essence,30000.0,2021
+179 000,Mercedes-Benz Classe C coupé AMG,Essence,40000.0,2019
+119 000,KIA Sportage GT-Line,Hybride,120000.0,2021
+88 000,BMW Série 3 318i,Essence,117000.0,2017
+43 500,Chery Tiggo 2 Confort,Essence,60000.0,2020
+87 000,Haval Jolion,Essence,40000.0,2022
+208 000,Mercedes-Benz Classe C AMG,Essence,40000.0,2022
+53 000,Hyundai Grand i10,Essence,54000.0,2021
+68 000,Seat Ibiza FR,Essence,100000.0,2020
+169 000,Mercedes-Benz CLA AMG,Essence,20000.0,2020
+67 000,Seat Ibiza FR,Essence,50000.0,2020
+85 000,Volkswagen T-roc,Essence,87000.0,2020
+113 000,Mercedes-Benz GLA AMG,Essence,74000.0,2016
+115 000,Mercedes-Benz Classe C AMG,Essence,170000.0,2014
+188 000,Audi Q3 Sportback,Essence,10000.0,2021
+215 000,Audi Q5,Diesel,100000.0,2018
+125 000,Volkswagen Golf 8 R-Line,Essence,70000.0,2021
+185 000,Jaguar F-Pace R-DYNAMIC,Diesel,165000.0,2017
+77 000,Peugeot 3008 GT-line,Essence,260000.0,2017
+Non dédouané                    350 000,Land Rover Range Rover Velar R-Dynamic,Diesel,100000.0,2019
+255 000,Porsche Panamera PLATINUM édition,Essence,100000.0,2014
+295 000,Land Rover Range Rover Velar R-Dynamic,Essence,90000.0,2020
+Sous leasing                    182 900,Dongfeng Forthing T5 EVO,Essence,4000.0,2023
+47 000,Chery Tiggo 3,Essence,75000.0,2018
+85 000,Audi Q3,Essence,77000.0,2017
+66 000,Renault Kadjar Intens,Essence,150000.0,2018
+155 000,Volkswagen Golf 8 R-Line,Essence,40000.0,2021
+205 000,Mercedes-Benz Classe C AMG,Hybride,35000.0,2020
+80 000,Volkswagen Golf 7 Join,Essence,120000.0,2019
+99 000,BMW Série 4 Gran Coupé Luxury,Essence,100000.0,2018
+161 000,Hyundai Tucson,Essence,24000.0,2023
+87 000,Hyundai Tucson,Essence,120000.0,2020
+92 000,BMW Série 1 Pack sport,Essence,70000.0,2020
+45 000,Fiat Panda City Cross,Essence,20000.0,2022
+125 000,BMW Série 4 Gran Coupé 418 PACK M,Essence,110000.0,2017
+77 000,Mercedes-Benz Classe E AMG,Essence,135000.0,2011
+215 000,Mercedes-Benz Classe C AMG,Essence,80000.0,2022
+65 000,Dongfeng SX3,Essence,30000.0,2021
+128 000,Volkswagen Golf 8 United,Essence,16000.0,2021
+172 000,Mercedes-Benz Classe A AMG,Essence,15000.0,2022
+148 000,Mercedes-Benz Classe C AMG,Diesel,80000.0,2019
+62 000,MG GS Luxe,Essence,115000.0,2017
+Sous leasing                    122 800,Mitsubishi ASX 4WD,Essence,55000.0,2021
+126 000,Land Rover Discovery,Diesel,130000.0,2017
+185 000,Audi A5 Sportback,Essence,70000.0,2021
+45 000,BMW Série 7 Individuel,Essence,300000.0,2008
+245 000,Land Rover Range Rover Sport,Diesel,160000.0,2014
+110 000,BMW Série 4 Coupé,Essence,78000.0,2017
+61 000,MG GS Luxe Plus,Essence,100000.0,2017
+40 000,Peugeot RCZ,Essence,171000.0,2011
+118 000,Land Rover Discovery Sport,Diesel,94000.0,2016
+87 000,Volkswagen Amarok AWD,Diesel,180000.0,2016
+55 000,BMW Série 7 740I FACE-LIFT,Essence,220000.0,2008
+69 000,Ford Ecosport Titanium,Essence,67000.0,2022
+120 000,Toyota Corolla Cross Hybride High,Hybride,36000.0,2022
+58 000,MG ZS Confort Plus,Essence,141000.0,2019
+85 000,KIA Sportage,Essence,150000.0,2019
+74 000,BMW Série 3 coupé Kit M///,Essence,152000.0,2012
+71 000,Mercedes-Benz Classe C AMG,Essence,200000.0,2011
+75 000,Audi A5 Coupé,Essence,109000.0,2014
+58 500,KIA Rio 5p SX,Essence,35000.0,2020
+36 500,BMW Série 1 Business Line,Essence,251000.0,2012
+78 000,Volkswagen Golf 7 Sound,Essence,125000.0,2018
+170 000,Mercedes-Benz CLA AMG,Hybride,25000.0,2021
+135 000,Mercedes-Benz Classe A AMG,Hybride,35000.0,2020
+50 000,Peugeot 308,Essence,102000.0,2020
+67 000,Ford Ecosport Titanium,Essence,44000.0,2022
+62 000,Fiat 500 Cult Club,Essence,3000.0,2023
+115 000,Mercedes-Benz Classe A AMG,Essence,60000.0,2021
+110 000,Volkswagen Tiguan R-Line,Essence,160000.0,2019
+40 000,Volkswagen Scirocco,Essence,200000.0,2010
+115 000,Audi A5 Sportback,Essence,80000.0,2019
+100 000,Hyundai Tucson,Diesel,81000.0,2018
+125 000,Land Rover Discovery,Essence,110000.0,2016
+110 000,Mercedes-Benz Classe A,Essence,90000.0,2021
+178 000,Hyundai Tucson Hybride Top Grade,Diesel,16000.0,2023
+51 000,Peugeot 508,Essence,145000.0,2018
+145 000,Mercedes-Benz Classe C coupé AMG,Essence,120000.0,2019
+230 000,Land Rover Range Rover Sport,Diesel,90000.0,2017
+220 000,Porsche Cayenne,Essence,158000.0,2015
+67 000,BMW Série 3,Essence,210000.0,2015
+108 000,Mercedes-Benz Classe A,Essence,50000.0,2020
+66 000,Mercedes-Benz Classe C,Essence,180000.0,2013
+83 000,Renault Kadjar,Essence,98000.0,2021
+85 000,Land Rover Range Rover Sport,Diesel,208000.0,2007
+200 000,Audi Q3,Hybride,40000.0,2023
+95 000,KIA Sorento,Diesel,120000.0,2016
+118 000,KIA Sportage,Diesel,140000.0,2018
+53 000,KIA Rio 5p SX PLUS,Essence,99000.0,2020
+Sous leasing                    47 100,Wallyscar 719,Essence,86573.0,2023
+61 000,Renault Megane Sedan,Essence,46000.0,2019
+78 000,Ford Ecosport,Essence,19000.0,2022
+58 000,Mercedes-Benz ML,Diesel,250000.0,2007
+36 000,Ford Focus Trend Sport,Essence,180000.0,2014
+65 000,Toyota Prado Adventure,Diesel,330000.0,1999
+27 500,Peugeot 207 Access Plus,Diesel,290000.0,2011
+145 000,Mercedes-Benz CLA,Diesel,60000.0,2021
+63 500,Hyundai ix35 Toit Panoramique,Diesel,160000.0,2016
+41 300,Volkswagen Polo Sedan Trendline,Essence,170000.0,2020
+68 500,Mercedes-Benz Classe A AMG,Essence,180000.0,2014
+420 000,Mercedes-Benz GLC Coupé AMG,Essence,0.0,2024
+105 000,Mercedes-Benz Classe C,Essence,200000.0,2014
+65 000,Ssangyong Tivoli Confort Plus,Essence,4700.0,2018
+63 000,Mini 3 portes John Cooper Works,Essence,100000.0,2017
+168 000,Toyota Hilux Double Cabine D4D,Diesel,140000.0,2020
+255 000,Land Rover Range Rover Evoque HSE,Hybride,60000.0,2022
+132 000,Mercedes-Benz Classe A Berline AMG,Essence,100000.0,2020
+385 000,Land Rover Range Rover Sport Autobiography,Hybride,60000.0,2021
+220 000,Mercedes-Benz CLA AMG,Essence,0.0,2024
+480 000,Porsche Cayenne Coupé GTS,Hybride,70000.0,2020
+450 000,Mercedes-Benz GLE Coupé,Hybride,30000.0,2022
+260 000,Mercedes-Benz Classe E AMG,Hybride,70000.0,2020
+270 000,Mercedes-Benz GLC Coupé AMG,Hybride,80000.0,2021
+145 000,BMW Série 4 Gran Coupé KIT-M-individual,Essence,120000.0,2016
+115 000,Mercedes-Benz CLA,Diesel,130000.0,2017
+145 000,Audi A3 Sportback 1.5,Hybride,900.0,2023
+190 000,Tesla Model 3 Modèle 3 Highland 2024,Electrique,15000.0,2023
+197 000,Mercedes-Benz GLC AMG,Hybride,130000.0,2018
+168 000,Mercedes-Benz Classe E,Diesel,158000.0,2020
+56 000,Nissan Qashqai,Diesel,147000.0,2016
+145 000,Hyundai Tucson,Essence,37000.0,2022
+95 000,Audi Q2 Design,Essence,77000.0,2019
+62 000,KIA Rio 5p,Essence,51000.0,2021
+85 000,Toyota C-HR,Essence,71000.0,2021
+78 000,KIA Sportage Black Edition,Essence,117000.0,2018
+26 000,Mahindra KUV 100 K6+,Essence,90000.0,2021
+75 000,Toyota C-HR,Essence,165000.0,2020
+28 000,Ford Fiesta Trend,Essence,161000.0,2013
+150 000,BMW Série 4 Coupé M,Essence,85000.0,2019
+60 000,Renault Megane Sedan,Essence,70000.0,2021
+104 000,Mazda CX-9 High grade,Essence,155000.0,2019
+29 500,Ford Fiesta Titanium,Essence,223000.0,2013
+26 000,Peugeot Partner,Diesel,320000.0,2009
+37 900,Suzuki Celerio,Essence,45000.0,2022
+144 900,Mercedes-Benz CLA AMG,Essence,100000.0,2020
+90 000,MG HS Trophy,Essence,111000.0,2022
+41 500,Seat Ibiza,Essence,83000.0,2019
+48 000,Ssangyong Tivoli,Essence,235000.0,2018
+32 500,Mahindra KUV 100 K6+,Essence,59000.0,2022
+18 000,Hyundai H-1,Essence,999999.0,2006
+"29,500 DT",Nissan Micra,Essence,130000.0,2017
+"28,600 DT",BMW Serie 1,Essence,240000.0,2007
+0 DT,Suzuki Swift,Essence,91000.0,2021
+0 DT,Skoda Fabia,Essence,78000.0,2021
+0 DT,Kia Optima,Essence,247000.0,2014
+"25,800 DT",Fiat Doblo,Diesel,160000.0,2020
+"78,000 DT",Mercedes-Benz Classe C,Essence,207600.0,2014
+"39,500 DT",Kia Cerato,Essence,14400.0,2015
+"55,500 DT",Kia Rio,Essence,90000.0,2021
+0 DT,Citroen Berlingo,Diesel,181000.0,2019
+0 DT,Renault Megane,Diesel,149000.0,2020
+"44,500 DT",Volkswagen Polo,Essence,140000.0,2021
+"30,500 DT",Renault Clio,Essence,116000.0,2012
+950 DT,Citroen C5,Essence,250.0,2024
+0 DT,Chevrolet S-10,Essence,64000.0,2021
+0 DT,Renault Clio,Essence,67000.0,2021
+"17,500 DT",Peugeot 207,Essence,229999.0,2012
+0 DT,Mercedes-Benz Classe A,Essence,48000.0,2019
+"20,000 DT",Citroen Nemo,Diesel,420000.0,2014
+"13,500 DT",Peugeot 306,Essence,202000.0,2000
+0 DT,Fiat Tipo,Diesel,113167.0,2020
+"34,000 DT",Citroen C3,Essence,97000.0,2018
+"29,000 DT",SsangYong Actyon,Diesel,424000.0,2015
+0 DT,Volkswagen Polo,Essence,84200.0,2021
+0 DT,Suzuki Celerio,Essence,58000.0,2021
+"9,000 DT",Opel Corsa,Essence,312.0,N.C
+"1,111 DT",Volkswagen Golf 5,Essence,170000.0,2007
+"66,500 DT",Peugeot 3008,Essence,100000.0,2019
+0 DT,Mercedes-Benz Classe A,N.C,32000.0,2021
+"78,000 DT",Peugeot Partner,Diesel,70000.0,2020
+0 DT,Kia Sportage,Diesel,139000.0,2018
+"41,500 DT",Skoda Fabia,Essence,130000.0,2021
+0 DT,Toyota Corolla,Essence,31000.0,2021
+0 DT,Mercedes-Benz Classe C,N.C,26000.0,2022
+0 DT,Haval H6,Essence,15000.0,2022
+0 DT,Renault Clio,Essence,95000.0,2020
+"105,000 DT",BMW Serie 4,Essence,150000.0,2019
+"152,000 DT",BMW X4,Essence,62000.0,2016
+0 DT,Mercedes-Benz Classe A,Essence,48000.0,2020
+0 DT,Volkswagen Golf,Essence,190000.0,2012
+0 DT,BMW Serie 5,Essence,140000.0,2017
+"53,000 DT",Fiat Tipo,Essence,113000.0,2020
+0 DT,Renault Clio,Diesel,,2021
+0 DT,Volkswagen Passat CC,Essence,111000.0,2019
+0 DT,Volkswagen Golf 8,Essence,38000.0,2021
+0 DT,Volkswagen Golf 7,Essence,81000.0,2018
+0 DT,Volkswagen Golf 7,Essence,71000.0,2019
+0 DT,Peugeot 208,Essence,65000.0,2020
+0 DT,Volkswagen Passat,N.C,50000.0,2020
+"48,500 DT",Renault Megane,Essence,150000.0,2020
+0 DT,Renault Clio,Essence,241000.0,2008
+"79,000 DT",Ford Focus,Essence,60000.0,2020
+"82,000 DT",Nissan Juke,Essence,27000.0,2023
+0 DT,Peugeot Partner,Diesel,119000.0,2021
+0 DT,Mitsubishi L200,Diesel,205000.0,2017
+"44,000 DT",Peugeot 2008,Essence,117000.0,2018
+"33,800 DT",Nissan Micra,Essence,74300.0,2020
+0 DT,SEAT Ibiza,Essence,,2014
+"67,000 DT",Mercedes-Benz Classe E,Essence,197000.0,2010
+"55,000 DT",Audi A6,Essence,166920.0,2016
+"41,000 DT",Hyundai i10,Essence,65000.0,2023
+0 DT,Volkswagen Golf 8,N.C,69000.0,2021
+0 DT,Alfa Romeo Giulietta,Essence,143000.0,2015
+0 DT,Volkswagen Passat,Essence,128000.0,2010
+"96,000 DT",Kia Sportage,Essence,45000.0,N.C
+0 DT,Fiat Linea,Essence,167000.0,2009
+"1,111 DT",Jeep Compass,Essence,64000.0,2020
+"1,111 DT",BMW Serie 4,Essence,150000.0,2019
+"1,111 DT",Land Rover Range Rover Sport,Hybride,42000.0,2020
+0 DT,Porsche Cayenne,Essence,10000.0,2015
+0 DT,Mercedes-Benz Classe A,Essence,89000.0,2020
+0 DT,Renault Captur,N.C,90000.0,2022
+"38,500 DT",Fiat Panda,Essence,130000.0,2022
+"42,000 DT",Ford Focus,Essence,120000.0,2016
+0 DT,Fiat Siena,Essence,200000.0,2006
+"75,000 DT",Kia Sportage,Essence,160000.0,2017
+"45,500 DT",Fiat 500C,Essence,71000.0,2017
+0 DT,Dacia Dokker,Diesel,127000.0,2021
+0 DT,Peugeot 308,Diesel,208000.0,2011
+0 DT,Hyundai Tucson,Essence,,2008
+0 DT,Volkswagen Golf,Diesel,182000.0,2012
+0 DT,Volkswagen Golf,Diesel,134000.0,2020
+"61,500 DT",Citroen DS5,Essence,110000.0,2017
+0 DT,Renault Clio,Essence,90000.0,2019
+"42,000 DT",Citroen C3,Essence,98270.0,2018
+0 DT,SEAT Ibiza,Essence,48000.0,2019
+"117,000 DT",Kia Sportage,N.C,54000.0,2020
+"58,000 DT",Volkswagen Passat,Essence,140000.0,2016
+"54,000 DT",Peugeot 2008,Essence,90000.0,2019
+"22,800 DT",Chery QQ,Essence,104000.0,2019
+"45,500 DT",Peugeot 208,Essence,78000.0,2021
+"78,000 DT",Audi A3,Essence,98000.0,2020
+"13,500 DT",Opel Corsa,Essence,266000.0,2000
+"70,000 DT",SEAT Leon,Essence,61847.0,2019
+0 DT,Mercedes-Benz Classe CLA,N.C,27000.0,2022
+"35,500 DT",Citroen C3,Essence,58000.0,2021
+"46,500 DT",Kia Picanto,Essence,28000.0,2021
+0 DT,Volkswagen Polo,Essence,81000.0,2022
+"90,000 DT",MG ZS,Essence,13.0,2024
+"47,000 DT",Nissan Navara,Diesel,315000.0,2012
+0 DT,Ford Fiesta,Essence,197000.0,2010
+0 DT,Toyota Aygo,Essence,60000.0,2017
+0 DT,Mercedes-Benz 220,Diesel,250000.0,2002
+0 DT,SEAT Ibiza,Essence,106000.0,2021
+0 DT,Volkswagen Golf,Essence,80000.0,2018
+0 DT,Kia Sportage,Diesel,24000.0,2017
+0 DT,Peugeot Partner,Diesel,105000.0,2020
+0 DT,Audi A3,Diesel,210000.0,2010
+"30,000 DT",Peugeot 508,Essence,268000.0,2012
+"40,500 DT",Renault Clio,Essence,110000.0,2016
+0 DT,Mercedes-Benz Classe A,Essence,68653.0,2018
+0 DT,BMW Serie 5,Diesel,287586.0,2007
+0 DT,Hyundai Grand i10,Essence,94260.0,2017
+0 DT,Kia Sportage,Diesel,207991.0,2018
+"19,500 DT",Renault Megane,Diesel,350000.0,2007
+0 DT,Peugeot 308,Essence,36799.0,2021
+"48,500 DT",Kia Rio,Essence,170000.0,2021
+"42,500 DT",Renault Clio,Essence,80000.0,2021
+0 DT,Toyota Hilux,Diesel,,2018
+0 DT,Kia Sportage,Essence,150000.0,2019
+0 DT,Renault Kadjar,Essence,60000.0,2023
+"8,500 DT",Renault Clio,Essence,300000.0,1993
+0 DT,Volkswagen Polo,Essence,189000.0,2012
+400 DT,Renault Clio,Essence,,2023
+0 DT,Citroen C3,Diesel,92000.0,2020
+0 DT,Mercedes-Benz Classe E,Essence,95000.0,2017
+0 DT,Fiat Doblo,Diesel,165000.0,2017
+"36,500 DT",Citroen C-Elysee,Essence,70000.0,2020
+0 DT,Renault Clio,Essence,150000.0,2006
+"52,000 DT",Volkswagen Polo,Essence,,2022
+"120,000 DT",Mazda BT-50,Essence,190000.0,2015
+0 DT,Audi A4,Essence,44000.0,2018
+"26,000 DT",Nissan Micra,Essence,160000.0,2013
+0 DT,Citroen Berlingo,Diesel,190000.0,2016
+0 DT,Peugeot Partner,Diesel,140000.0,2020
+"61,500 DT",Kia Rio,Essence,48000.0,2024
+"12,800 DT",Opel Corsa,Essence,350000.0,2000
+0 DT,Renault Clio,Essence,150000.0,2014
+0 DT,Suzuki Celerio,Essence,50000.0,2023
+0 DT,Volkswagen Polo,Essence,190000.0,2017
+0 DT,Mahindra Hover,Essence,2000.0,2024
+0 DT,Dacia Logan MCV,Essence,20000.0,2023
+0 DT,Renault Symbol,Essence,120000.0,2012
+"46,000 DT",Mazda CX-9,Essence,286000.0,2010
+0 DT,Volkswagen Golf,Diesel,203588.0,2012
+0 DT,Peugeot 208,Essence,112223.0,2017
+0 DT,Renault Symbol,Essence,195000.0,2011
+"41,000 DT",Renault Clio,Essence,91300.0,2020
+"61,000 DT",SsangYong Tivoli,Essence,74000.0,2020
+"77,500 DT",Mercedes-Benz Classe CLA,Essence,170000.0,2014
+"67,500 DT",BMW X5,Diesel,280000.0,2008
+"40,900 DT",Toyota Aygo,Essence,90000.0,2021
+"9,000 DT",Peugeot 205,Essence,111000.0,1993
+"27,500 DT",Peugeot 207,Diesel,290000.0,2011
+0 DT,BMW Serie 1,Essence,144000.0,2015
+0 DT,Kia Sportage,N.C,100000.0,2020
+0 DT,Volkswagen Polo,Essence,116000.0,2021
+0 DT,Hyundai Grand i10,Essence,90000.0,2021
+"1,000 DT",Renault R4,Essence,57000.0,1980
+"10,000 DT",Renault Clio,Essence,123000.0,2005
+"190,000 DT",Hyundai Santa Fe,Diesel,48000.0,2020
+0 DT,Mazda 6,Essence,157000.0,2018
+"19,000 DT",Peugeot 206,Essence,,2001
+"32,000 DT",Fiat Fiorino,Diesel,112000.0,2019
+0 DT,Citroen C3,Essence,81000.0,2021
+"173,000 DT",Mercedes-Benz Classe C,Essence,9000.0,2021
+0 DT,Volkswagen Golf,Essence,130000.0,2015
+"27,000 DT",Chevrolet Spark,Essence,121000.0,2015
+"35,000 DT",Peugeot 308,Essence,168000.0,2015
+"37,000 DT",SEAT Ibiza,Essence,205000.0,2020
+0 DT,Volkswagen Polo,Essence,80000.0,2021
+"51,500 DT",Hyundai i20,Essence,72000.0,2022
+"19,700 DT",Citroen C3,Essence,195540.0,2007
+"85,000 DT",Toyota C-HR,Essence,711000.0,2021
+"25,000 DT",Volkswagen Polo,Essence,47000.0,2006
+"33,000 DT",Hyundai i10,Essence,88000.0,2018
+0 DT,Mazda BT-50,Diesel,,2009
+"38,500 DT",Citroen Berlingo,Diesel,76470.0,2015
+0 DT,Peugeot 208,Essence,48000.0,2022
+"220,000 DT",Mercedes-Benz Classe A,Essence,10000.0,2002
+"64,000 DT",Volkswagen Caddy,Diesel,124000.0,2020
+"33,000 DT",Peugeot Partner,Diesel,282000.0,2016
+0 DT,Mercedes-Benz Classe B,Essence,226000.0,2009
+"65,000 DT",BMW X5,Essence,154000.0,2009
+"30,000 DT",Peugeot 208,Essence,113000.0,2017
+"56,000 DT",Volkswagen Passat,Diesel,300000.0,2013
+0 DT,Nissan Micra,Essence,190000.0,2018
+0 DT,Renault Megane,Diesel,2021.0,2021
+0 DT,Citroen Berlingo,Diesel,95000.0,2020
+0 DT,BMW Serie 1,Essence,185000.0,2016
+0 DT,Kia Picanto,Essence,30000.0,2022
+0 DT,Dacia Sandero,Essence,78000.0,2021
+0 DT,Peugeot 208,Essence,28000.0,2023
+"75,000 DT",Toyota C-HR,Essence,165000.0,2020
+0 DT,Suzuki Celerio,Essence,70000.0,2021
+"60,000 DT",Renault Megane,Essence,60000.0,2021
+"25,000 DT",Mercedes-Benz Classe A,Essence,100000.0,2002
+"8,000 DT",Peugeot 206,Diesel,,2003
+0 DT,Volkswagen Golf 8,Essence,60000.0,2021
+"22,000 DT",Peugeot 301,Essence,106000.0,2014
+"24,500 DT",Peugeot 301,Essence,170000.0,2015
+0 DT,Citroen Nemo,Diesel,232000.0,2018
+0 DT,Volkswagen Golf 4,Essence,298000.0,2000
+"42,500 DT",Suzuki Swift,Essence,49500.0,2019
+"42,300 DT",Kia Picanto,Essence,74000.0,2020
+0 DT,Renault Clio,Essence,231.0,N.C
+"40,000 DT",Kia Picanto,Essence,77000.0,2021
+0 DT,Mercedes-Benz Classe C,Essence,,2012
+0 DT,Audi Q5,Electrique,53000.0,2021
+0 DT,Dacia Duster,Essence,170000.0,2013
+0 DT,Hyundai i10,Essence,90.0,N.C
+"26,500 DT",Fiat Grande Punto,Essence,194500.0,2014
+"32,000 DT",Peugeot 308,Essence,180000.0,2015
+"43,000 DT",Renault Clio,Essence,105000.0,2020
+0 DT,Mercedes-Benz Classe C,Essence,,2010
+0 DT,Peugeot Partner,Diesel,90000.0,2012
+"24,800 DT",Renault Clio,Essence,200000.0,2010
+0 DT,Volkswagen Polo,Essence,186000.0,2011
+"42,500 DT",Volkswagen Polo,Essence,92500.0,2021
+"28,000 DT",Volkswagen Passat,Diesel,,2000
+0 DT,Skoda Fabia,Essence,82000.0,2021
+"15,500 DT",Chevrolet Aveo,Essence,258000.0,2005
+"15,500 DT",Renault Symbol,Essence,390000.0,2010
+0 DT,Volkswagen Polo,Diesel,200000.0,2001
+"175,000 DT",Volkswagen Golf 7,Essence,75000.0,2020
+"33,500 DT",BMW Serie 3,Essence,248000.0,2007
+0 DT,Hyundai i20,Essence,47000.0,2022
+"38,000 DT",Hyundai Accent,Essence,141000.0,2016

--- a/data_structuring.py
+++ b/data_structuring.py
@@ -1,0 +1,156 @@
+import pandas as pd
+
+
+pd.set_option('display.max_columns', None)  # Show all columns
+pd.set_option('display.max_rows', 10)      # Adjust the maximum rows as needed
+pd.set_option('display.expand_frame_repr', False)  # Prevent line wrapping
+
+df1 = pd.read_csv("data/car_listings.csv")
+df2 = pd.read_csv("data/car_listings_autoprix.csv")
+df3 = pd.read_csv("data/car_listings_baniola2.csv")
+df4 = pd.read_csv("data/car_listings_karahba.csv")
+
+
+print("df1:\n",df1.columns)
+print("df2:\n",df2.columns)
+print("df3:\n",df3.columns)
+print("df4:\n",df4.columns)
+
+df1.rename(columns={'title': 'Make', 'car_year': 'Year'}, inplace=True)
+df2.rename(columns={'title': 'Title', 'price': 'Price', 'year': 'Year', 'fuel_type': 'Fuel', 'mileage': 'Mileage'}, inplace=True)
+df3.rename(columns={'Price (TND)': 'Price', 'Fuel Type': 'Fuel'}, inplace=True)
+df4.rename(columns={'brand': 'Make', 'manufacture_year': 'Year'}, inplace=True)
+
+print("After Renaming")
+
+print("df1:\n",df1.columns)
+print("df2:\n",df2.columns)
+print("df3:\n",df3.columns)
+print("df4:\n",df4.columns)
+
+# Simulated column names for each dataset
+columns_df1 = ['Title', 'Mileage', 'Year', 'Transmission', 'Fuel', 'Price']
+columns_df2 = ['Title', 'location', 'Price', 'Year', 'Mileage', 'Fuel']
+columns_df3 = ['Price', 'Location', 'Title', 'Fuel', 'Year']
+columns_df4 = ['Title', 'Brand', 'Price', 'Mileage', 'Phone', 'Location', 'Date']
+
+# Combine all columns and identify unique ones
+all_columns = set(columns_df1 + columns_df2 + columns_df3 + columns_df4)
+
+# Determine common columns across all datasets
+common_columns = list(set(columns_df1) & set(columns_df2) & set(columns_df3) & set(columns_df4))
+
+# Rearrange all columns: common first, unique at the end
+ordered_columns = common_columns + sorted(all_columns - set(common_columns))
+
+# Function to rearrange and fill missing columns
+def rearrange_columns(df, column_order):
+    # Reindex the DataFrame with the new column order, filling missing columns with NaN
+    return df.reindex(columns=column_order, fill_value=None)
+
+# Rearrange columns for each DataFrame
+df1 = rearrange_columns(df1, ordered_columns)
+df2 = rearrange_columns(df2, ordered_columns)
+df3 = rearrange_columns(df3, ordered_columns)
+df4 = rearrange_columns(df4, ordered_columns)
+
+# # Concatenate the datasets
+# combined_df = pd.concat([df1, df2, df3, df4], ignore_index=True)
+
+# Display column order and final DataFrame
+print("Ordered Columns for datasets:")
+# print(combined_df.head())
+
+print("df1:\n",df1.columns)
+print("df2:\n",df2.columns)
+print("df3:\n",df3.columns)
+print("df4:\n",df4.columns)
+
+print("df1:\n",df1)
+print("df2:\n",df2)
+print("df3:\n",df3)
+print("df4:\n",df4)
+
+
+# Combine Title and Brand
+def combine_title_and_brand(row):
+    title = row['Title']
+    brand = row['Brand']
+
+    if pd.isna(brand) or brand == 'None':  # If no brand exists, do nothing
+        return title
+    elif brand in title:  # If brand is already in the title, keep the title as-is
+        return title
+    else:  # Otherwise, combine brand and title
+        return f"{brand} {title}"
+
+
+# Apply the function
+df1['Title'] = df1.apply(combine_title_and_brand, axis=1)
+
+# Drop the Brand column
+df1.drop(columns=['Brand'], inplace=True)
+
+# Apply the function
+df2['Title'] = df2.apply(combine_title_and_brand, axis=1)
+
+# Drop the Brand column
+df2.drop(columns=['Brand'], inplace=True)
+
+# Apply the function
+df3['Title'] = df3.apply(combine_title_and_brand, axis=1)
+
+# Drop the Brand column
+df3.drop(columns=['Brand'], inplace=True)
+
+# Apply the function
+df4['Title'] = df4.apply(combine_title_and_brand, axis=1)
+
+# Drop the Brand column
+df4.drop(columns=['Brand'], inplace=True)
+
+# Drop the 'Date' column if it exists
+df1 = df1.drop(columns=['Date'], errors='ignore')
+df2 = df2.drop(columns=['Date'], errors='ignore')
+df3 = df3.drop(columns=['Date'], errors='ignore')
+df4 = df4.drop(columns=['Date'], errors='ignore')
+
+# Drop the 'location' column if it exists
+df1 = df1.drop(columns=['location'], errors='ignore')
+df2 = df2.drop(columns=['location'], errors='ignore')
+df3 = df3.drop(columns=['location'], errors='ignore')
+df4 = df4.drop(columns=['location'], errors='ignore')
+
+# Drop the 'Location' column if it exists
+df1 = df1.drop(columns=['Location'], errors='ignore')
+df2 = df2.drop(columns=['Location'], errors='ignore')
+df3 = df3.drop(columns=['Location'], errors='ignore')
+df4 = df4.drop(columns=['Location'], errors='ignore')
+
+# Drop the 'Transmission' column if it exists
+df1 = df1.drop(columns=['Transmission'], errors='ignore')
+df2 = df2.drop(columns=['Transmission'], errors='ignore')
+df3 = df3.drop(columns=['Transmission'], errors='ignore')
+df4 = df4.drop(columns=['Transmission'], errors='ignore')
+
+
+# Drop the 'Phone' column if it exists
+df1 = df1.drop(columns=['Phone'], errors='ignore')
+df2 = df2.drop(columns=['Phone'], errors='ignore')
+df3 = df3.drop(columns=['Phone'], errors='ignore')
+df4 = df4.drop(columns=['Phone'], errors='ignore')
+
+
+print("Brand and Title combined / Dropping Date ,Location and Phone:")
+
+print("df1:\n",df1)
+print("df2:\n",df2)
+print("df3:\n",df3)
+print("df4:\n",df4)
+
+# Concatenate datasets
+combined_df = pd.concat([df1, df2], ignore_index=True)
+combined_df.to_csv("clean_data/preset1.csv", index=False)
+
+# Display the combined DataFrame
+print(combined_df)

--- a/preset1_script.py
+++ b/preset1_script.py
@@ -1,0 +1,101 @@
+import re
+import pandas as pd
+from datetime import datetime
+
+# Load the dataset
+df = pd.read_csv("clean_data/preset1.csv")
+
+# Function to extract and convert mileage to integer
+def clean_mileage(value):
+    if pd.isna(value):  # Handle NaN values
+        return None
+    # Extract digits only, ignoring non-digit characters
+    value = ''.join(filter(str.isdigit, str(value)))
+    return int(value) if value.isdigit() else None
+
+# Function to extract and convert price to integer
+def clean_price(value):
+    if pd.isna(value):  # Handle NaN values
+        return None
+    # Extract digits only, ignoring non-digit characters
+    value = ''.join(filter(str.isdigit, str(value)))
+    return int(value) if value.isdigit() else None
+
+# Function to clean and validate the year
+def clean_year(value):
+    try:
+        year = int(float(value))  # Convert to integer (handles values like 2016.0)
+        current_year = datetime.now().year
+        if 1900 <= year <= current_year:
+            return year
+    except (ValueError, TypeError):
+        pass
+    return None  # Return None for invalid years
+
+# List of multi-word brands
+multi_word_brands = [
+    "Land Rover", "Mercedes-Benz", "BMW X", "Alfa Romeo", "Rolls-Royce", "BMW M", "Nissan Nismo",
+    "Mercedes-AMG", "Audi Sport", "Great Wall", "SAIC Motor", "Faraday Future", "GAC Group",
+    "Toyota Crown", "Chevrolet Silverado", "Chevrolet Corvette"
+]
+
+# Function to clean and split the Title into Brand and Model
+def split_title(title):
+    # Iterate over multi-word brands and match them in the title
+    for brand in multi_word_brands:
+        if brand in title:
+            # If the title contains a multi-word brand, treat the brand as the first part
+            Model = title.replace(brand, "").strip()
+            return brand, Model
+
+    # Default case: split by first space (first word is the brand, the rest is the Model)
+    # This regex ensures that we handle titles with spaces more effectively
+    match = re.match(r'(\S+)(?:\s+(.+))?', title)
+    if match:
+        return match.group(1), match.group(2)
+
+    return title, None  # If no match, return the entire title as brand and None for Model
+
+# Apply cleaning functions
+df['Mileage'] = df['Mileage'].apply(clean_mileage).astype('Int64')  # Ensures it's an integer
+df['Price'] = df['Price'].apply(clean_price).astype('Int64')  # Ensure price is an integer
+
+# Remove rows with Price equal to 0
+df = df[df['Price'] != 0]
+
+df['Year'] = df['Year'].apply(clean_year).astype('Int64')  # Ensures Year is an integer
+
+# Split Title into Brand and Model
+df[['Brand', 'Model']] = df['Title'].apply(split_title).apply(pd.Series)
+
+# Drop the original Title column
+df = df.drop(columns=['Title'])
+
+# Rearrange columns to the desired order
+df = df[['Brand', 'Model', 'Fuel', 'Mileage', 'Year', 'Price']]
+
+# Save the cleaned and structured DataFrame
+df.to_csv("clean_data/preset1_cleaned_final.csv", index=False)
+
+# Display the structured DataFrame
+print("Structured Data:\n", df)
+
+# Get unique brands
+unique_brands = df['Brand'].unique()
+
+# Print the unique brands
+print("Unique Brands in the dataset: ",len(unique_brands))
+for brand in unique_brands:
+    print(brand)
+
+# Step 1: Modify only DS-related rows
+df.loc[df['Brand'] == 'DS', 'Brand'] = 'Citroen'  # Change DS to Citroen for DS rows
+df.loc[df['Brand'] == 'Citroen', 'Model'] = 'DS ' + df['Model']  # Add "DS " to version ONLY for Citroen rows that were originally DS
+
+
+# Get the frequency (redundancy) of each brand
+brand_counts = df['Brand'].value_counts()
+
+# Print the frequency of each brand
+print("Redundancy of each brand:")
+print(brand_counts)

--- a/sturcturingdf3.py
+++ b/sturcturingdf3.py
@@ -1,0 +1,42 @@
+import pandas as pd
+import re
+
+df = pd.read_csv("data/car_listings_baniola.csv")
+
+
+
+# Function to extract fuel type and year
+
+
+
+def extract_info(row):
+    title = row['Title']
+    fuel_types = ['Essence', 'Diesel','Hybride']
+
+    # Extract fuel type
+    fuel_type = next((fuel for fuel in fuel_types if fuel in title), None)
+
+    # Extract year (4 consecutive digits)
+    year_match = re.search(r'\b(19|20)\d{2}\b', title)
+    year = year_match.group() if year_match else None
+
+    # Remove fuel type and year from the title
+    clean_title = title
+    if fuel_type:
+        clean_title = clean_title.replace(fuel_type, '').strip()
+    if year:
+        clean_title = re.sub(r'\b(19|20)\d{2}\b', '', clean_title).strip()
+
+    # Return cleaned data
+    return pd.Series([clean_title, fuel_type, year])
+
+
+# Apply extraction function to the dataset
+df[['Clean Title', 'Fuel Type', 'Year']] = df.apply(extract_info, axis=1)
+
+# Drop original Title column and rename Clean Title
+df.drop(columns=['Title'], inplace=True)
+df.rename(columns={'Clean Title': 'Title'}, inplace=True)
+df.to_csv("data/car_listings_baniola2.csv", index=False)
+# Display cleaned DataFrame
+print(df)


### PR DESCRIPTION
- Dropped original 'Title' column and renamed cleaned data.
- Saved the processed dataset as 'car_listings_baniola2.csv'.
- Standardized column names across multiple datasets.
- Combined 'Title' and 'Brand' columns and removed 'Brand' column.
- Dropped unnecessary columns ('Date', 'Location', 'Phone', 'Transmission').
- Merged `df1` and `df2` into a combined dataset and saved as 'preset1.csv'.
- Cleaned 'Mileage', 'Price', and 'Year' columns with custom validation and conversion.
- Split 'Title' into 'Brand' and 'Model' while handling multi-word brands.
- Made adjustments to 'DS' brand rows (replaced with 'Citroen' and updated the model name).
- Saved the final cleaned dataset as 'preset1_cleaned_final.csv'.
- Displayed unique brands and redundancy count.